### PR TITLE
LGTM画像を配信する為のCDNを作成

### DIFF
--- a/modules/aws/acm/main.tf
+++ b/modules/aws/acm/main.tf
@@ -1,0 +1,7 @@
+data "aws_acm_certificate" "main" {
+  domain = var.main_domain_name
+}
+
+data "aws_acm_certificate" "sub" {
+  domain = "*.${var.main_domain_name}"
+}

--- a/modules/aws/acm/outputs.tf
+++ b/modules/aws/acm/outputs.tf
@@ -1,0 +1,7 @@
+output "main_domain_acm_arn" {
+  value = data.aws_acm_certificate.main.arn
+}
+
+output "sub_domain_acm_arn" {
+  value = data.aws_acm_certificate.sub.arn
+}

--- a/modules/aws/acm/variables.tf
+++ b/modules/aws/acm/variables.tf
@@ -1,0 +1,3 @@
+variable "main_domain_name" {
+  type = string
+}

--- a/modules/aws/images/main.tf
+++ b/modules/aws/images/main.tf
@@ -20,3 +20,117 @@ resource "aws_s3_bucket" "lgtm_images_bucket" {
     }
   }
 }
+
+resource "aws_cloudfront_origin_access_identity" "lgtm_images_bucket" {
+  comment = "${aws_s3_bucket.lgtm_images_bucket.bucket} origin access identity"
+}
+
+data "aws_iam_policy_document" "read_lgtm_images" {
+  statement {
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.lgtm_images_bucket.arn}/*"]
+
+    principals {
+      identifiers = [aws_cloudfront_origin_access_identity.lgtm_images_bucket.iam_arn]
+      type        = "AWS"
+    }
+  }
+
+  statement {
+    actions   = ["s3:ListBucket"]
+    resources = [aws_s3_bucket.lgtm_images_bucket.arn]
+
+    principals {
+      identifiers = [aws_cloudfront_origin_access_identity.lgtm_images_bucket.iam_arn]
+      type        = "AWS"
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "read_lgtm_images" {
+  bucket = aws_s3_bucket.lgtm_images_bucket.id
+  policy = data.aws_iam_policy_document.read_lgtm_images.json
+}
+
+resource "aws_s3_bucket" "lgtm_images_access_logs" {
+  bucket        = "${var.lgtm_images_bucket_name}-logs"
+  force_destroy = true
+
+  lifecycle_rule {
+    enabled                                = true
+    abort_incomplete_multipart_upload_days = 7
+  }
+}
+
+resource "aws_cloudfront_distribution" "lgtm_images_cdn" {
+  default_cache_behavior {
+    allowed_methods = ["GET", "HEAD"]
+    cached_methods  = ["GET", "HEAD"]
+
+    forwarded_values {
+      cookies {
+        forward = "none"
+      }
+
+      query_string = false
+    }
+
+    target_origin_id       = "S3-${aws_s3_bucket.lgtm_images_bucket.bucket}"
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  enabled         = true
+  is_ipv6_enabled = true
+  comment         = "LGTMeow Images"
+
+  aliases = [var.lgtm_images_cdn_domain]
+
+  logging_config {
+    bucket          = aws_s3_bucket.lgtm_images_access_logs.bucket_domain_name
+    include_cookies = false
+    prefix          = "raw/"
+  }
+
+  origin {
+    domain_name = aws_s3_bucket.lgtm_images_bucket.bucket_domain_name
+    origin_id   = "S3-${aws_s3_bucket.lgtm_images_bucket.bucket}"
+
+    s3_origin_config {
+      origin_access_identity = aws_cloudfront_origin_access_identity.lgtm_images_bucket.cloudfront_access_identity_path
+    }
+
+    custom_header {
+      name  = "Accept"
+      value = "image/png,image/jpeg,image/webp"
+    }
+
+    custom_header {
+      name  = "Content-Type"
+      value = "image/png,image/jpeg,image/webp"
+    }
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = var.lgtm_images_cdn_acm_arn
+    minimum_protocol_version = "TLSv1.2_2019"
+    ssl_support_method       = "sni-only"
+  }
+}
+
+resource "aws_route53_record" "lgtm_images" {
+  name    = var.lgtm_images_cdn_sub_domain
+  type    = "A"
+  zone_id = var.main_host_zone
+
+  alias {
+    evaluate_target_health = false
+    name                   = aws_cloudfront_distribution.lgtm_images_cdn.domain_name
+    zone_id                = aws_cloudfront_distribution.lgtm_images_cdn.hosted_zone_id
+  }
+}

--- a/modules/aws/images/variables.tf
+++ b/modules/aws/images/variables.tf
@@ -1,3 +1,19 @@
 variable "lgtm_images_bucket_name" {
   type = string
 }
+
+variable "lgtm_images_cdn_sub_domain" {
+  type = string
+}
+
+variable "lgtm_images_cdn_domain" {
+  type = string
+}
+
+variable "lgtm_images_cdn_acm_arn" {
+  type = string
+}
+
+variable "main_host_zone" {
+  type = string
+}

--- a/providers/aws/environments/prod/10-acm/.terraform.lock.hcl
+++ b/providers/aws/environments/prod/10-acm/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.29.0"
+  constraints = "3.29.0"
+  hashes = [
+    "h1:euXiL7Q/8CZ7eFO8ktcDVNEV51tJpicreQGazmNSGCg=",
+    "zh:0e3ec82025efcfed94180858240a1be147bc3eabb24a755f8c58970173b71e54",
+    "zh:22897ef5b00317ffa2495a5582c567a4ceca09e9071e0888b18c8364bab6d31b",
+    "zh:2e98fc511787045e5ef6f0e76d92ea8de27cd168b20902f9e57d75c96dcb80d8",
+    "zh:4e86f7f25c27c139ae17e3ad2a82a154b115d83f16bf8d8fee2aba9f00c80437",
+    "zh:71ba0b2b10a5e83b276ebca1d8559354c12656310bfd2554591ac6f0f5541bd0",
+    "zh:771989dadb5921bf4586c749a537116eaafdd854e542c5890c9dac55d7b2f8ac",
+    "zh:7aa3095c12174b6f8f525ba6007312df6b95de4b4137d25414144e7731ac202c",
+    "zh:a1c6f9a6f1abee0cc9c4a3a912c0e6571e7cc439701f03172de44b4187e66769",
+    "zh:bd50937e68e9434fc482817e9acfe486b95c69494194627884091a0581a0dffd",
+    "zh:e035fd1df86f709374a8547ac141edd1bd899cc7d979b7b28da3ad62fa6ff47b",
+  ]
+}

--- a/providers/aws/environments/prod/10-acm/backend.tf
+++ b/providers/aws/environments/prod/10-acm/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket  = "lgtm-cat-tfstate"
+    key     = "acm/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "lgtm-cat"
+  }
+}

--- a/providers/aws/environments/prod/10-acm/main.tf
+++ b/providers/aws/environments/prod/10-acm/main.tf
@@ -1,0 +1,15 @@
+module "ap_northeast_1_acm" {
+  source = "../../../../../modules/aws/acm"
+
+  main_domain_name = local.main_domain_name
+}
+
+module "us_east_1_acm" {
+  source = "../../../../../modules/aws/acm"
+
+  main_domain_name = local.main_domain_name
+
+  providers = {
+    aws = aws.us-east-1
+  }
+}

--- a/providers/aws/environments/prod/10-acm/outputs.tf
+++ b/providers/aws/environments/prod/10-acm/outputs.tf
@@ -1,0 +1,15 @@
+output "ap_northeast_1_main_domain_acm_arn" {
+  value = module.ap_northeast_1_acm.main_domain_acm_arn
+}
+
+output "ap_northeast_1_sub_domain_acm_arn" {
+  value = module.ap_northeast_1_acm.sub_domain_acm_arn
+}
+
+output "us_east_1_main_domain_acm_arn" {
+  value = module.us_east_1_acm.main_domain_acm_arn
+}
+
+output "us_east_1_sub_domain_acm_arn" {
+  value = module.us_east_1_acm.sub_domain_acm_arn
+}

--- a/providers/aws/environments/prod/10-acm/provider.tf
+++ b/providers/aws/environments/prod/10-acm/provider.tf
@@ -1,0 +1,10 @@
+provider "aws" {
+  region  = "ap-northeast-1"
+  profile = "lgtm-cat"
+}
+
+provider "aws" {
+  region  = "us-east-1"
+  profile = "lgtm-cat"
+  alias   = "us-east-1"
+}

--- a/providers/aws/environments/prod/10-acm/variables.tf
+++ b/providers/aws/environments/prod/10-acm/variables.tf
@@ -1,0 +1,4 @@
+locals {
+  env              = "prod"
+  main_domain_name = "lgtmeow.com"
+}

--- a/providers/aws/environments/prod/10-acm/versions.tf
+++ b/providers/aws/environments/prod/10-acm/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = "0.14.7"
+
+  required_providers {
+    aws = "3.29.0"
+  }
+}

--- a/providers/aws/environments/prod/11-images/backend.tf
+++ b/providers/aws/environments/prod/11-images/backend.tf
@@ -6,3 +6,14 @@ terraform {
     profile = "lgtm-cat"
   }
 }
+
+data "terraform_remote_state" "acm" {
+  backend = "s3"
+
+  config = {
+    bucket  = "lgtm-cat-tfstate"
+    key     = "acm/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "lgtm-cat"
+  }
+}

--- a/providers/aws/environments/prod/11-images/main.tf
+++ b/providers/aws/environments/prod/11-images/main.tf
@@ -1,4 +1,8 @@
 module "images" {
-  source                  = "../../../../../modules/aws/images"
-  lgtm_images_bucket_name = local.lgtm_images_bucket_name
+  source                     = "../../../../../modules/aws/images"
+  lgtm_images_bucket_name    = local.lgtm_images_bucket_name
+  lgtm_images_cdn_sub_domain = local.lgtm_images_cdn_sub_domain
+  lgtm_images_cdn_domain     = local.lgtm_images_cdn_domain
+  lgtm_images_cdn_acm_arn    = local.lgtm_images_cdn_acm_arn
+  main_host_zone             = data.aws_route53_zone.main_host_zone.zone_id
 }

--- a/providers/aws/environments/prod/11-images/variables.tf
+++ b/providers/aws/environments/prod/11-images/variables.tf
@@ -1,5 +1,18 @@
 locals {
-  env                     = "prod"
-  name                    = "lgtmeow"
-  lgtm_images_bucket_name = "${local.env}-${local.name}-images"
+  env                        = "prod"
+  name                       = "lgtmeow"
+  lgtm_images_bucket_name    = "${local.env}-${local.name}-images"
+  lgtm_images_cdn_sub_domain = "lgtm-images"
+  lgtm_images_cdn_domain     = "${local.lgtm_images_cdn_sub_domain}.${var.main_domain_name}"
+  lgtm_images_cdn_acm_arn    = data.terraform_remote_state.acm.outputs.us_east_1_sub_domain_acm_arn
+  main_host_zone             = data.aws_route53_zone.main_host_zone
+}
+
+variable "main_domain_name" {
+  type    = string
+  default = "lgtmeow.com"
+}
+
+data "aws_route53_zone" "main_host_zone" {
+  name = var.main_domain_name
 }

--- a/terraform-init.sh
+++ b/terraform-init.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 tfstateDirList='
+/data/providers/aws/environments/prod/10-acm
 /data/providers/aws/environments/prod/11-images
 '
 


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-terraform/issues/3

# 関連URL

## 画像サーバーの動作確認用のURL

https://lgtm-images.lgtmeow.com/test/1.jpg
https://lgtm-images.lgtmeow.com/test/2.jpg
https://lgtm-images.lgtmeow.com/test/3.jpg
https://lgtm-images.lgtmeow.com/test/3.webp

# Doneの定義
- S3にアップロードした画像がCloudFrontで閲覧出来る状態になっている事

# 変更点概要

ACMの証明書とCloudFrontを追加。

以下のURLでテスト画像を用意し閲覧出来る事を確認。

https://lgtm-images.lgtmeow.com/test/1.jpg
https://lgtm-images.lgtmeow.com/test/2.jpg

webp形式の画像も問題なく配信出来ることを確認。

https://lgtm-images.lgtmeow.com/test/3.jpg （こっちが3.webpの元画像）

https://lgtm-images.lgtmeow.com/test/3.webp

# 補足情報
webpへの変換は以下のブログを参考に行った。
https://blog.ideamans.com/2020/08/webp-params-2020.html

手順としては以下を実行するだけ。


```
// `3.jpg` が変換元の画像ファイルパスを指定し `3.webp` はファイル名を指定する。
cwebp -q 75 -metadata icc -sharp_yuv -o 3.webp 3.jpg
```

`cwebp` に関しては [こちらの手順](https://iwb.jp/cwebp-how-to-convert-multiple-images/) でインストール可能。

元々1.4MBあった画像が363KBまで落ちているので、配信フォーマットを `.webp` 形式にするのは一定の効果がありそう。

![sizemin](https://user-images.githubusercontent.com/11032365/108977274-b8744b80-76cb-11eb-9340-6b11fbd40d22.png)