### PR TITLE
Vercel上から独自ドメインでアクセスさせる為に必要なリソースを追加

### DIFF
--- a/modules/aws/vercel/domains/apex/main.tf
+++ b/modules/aws/vercel/domains/apex/main.tf
@@ -1,0 +1,7 @@
+resource "aws_route53_record" "apex_domain_record" {
+  name    = var.main_domain_name
+  type    = "A"
+  zone_id = var.main_host_zone
+  records = [var.a_record_value]
+  ttl     = "5"
+}

--- a/modules/aws/vercel/domains/apex/variables.tf
+++ b/modules/aws/vercel/domains/apex/variables.tf
@@ -1,0 +1,11 @@
+variable "main_host_zone" {
+  type = string
+}
+
+variable "main_domain_name" {
+  type = string
+}
+
+variable "a_record_value" {
+  type = string
+}

--- a/providers/aws/environments/prod/12-vercel/.terraform.lock.hcl
+++ b/providers/aws/environments/prod/12-vercel/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.29.0"
+  constraints = "3.29.0"
+  hashes = [
+    "h1:euXiL7Q/8CZ7eFO8ktcDVNEV51tJpicreQGazmNSGCg=",
+    "zh:0e3ec82025efcfed94180858240a1be147bc3eabb24a755f8c58970173b71e54",
+    "zh:22897ef5b00317ffa2495a5582c567a4ceca09e9071e0888b18c8364bab6d31b",
+    "zh:2e98fc511787045e5ef6f0e76d92ea8de27cd168b20902f9e57d75c96dcb80d8",
+    "zh:4e86f7f25c27c139ae17e3ad2a82a154b115d83f16bf8d8fee2aba9f00c80437",
+    "zh:71ba0b2b10a5e83b276ebca1d8559354c12656310bfd2554591ac6f0f5541bd0",
+    "zh:771989dadb5921bf4586c749a537116eaafdd854e542c5890c9dac55d7b2f8ac",
+    "zh:7aa3095c12174b6f8f525ba6007312df6b95de4b4137d25414144e7731ac202c",
+    "zh:a1c6f9a6f1abee0cc9c4a3a912c0e6571e7cc439701f03172de44b4187e66769",
+    "zh:bd50937e68e9434fc482817e9acfe486b95c69494194627884091a0581a0dffd",
+    "zh:e035fd1df86f709374a8547ac141edd1bd899cc7d979b7b28da3ad62fa6ff47b",
+  ]
+}

--- a/providers/aws/environments/prod/12-vercel/backend.tf
+++ b/providers/aws/environments/prod/12-vercel/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket  = "lgtm-cat-tfstate"
+    key     = "vercel/domains/apex/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "lgtm-cat"
+  }
+}

--- a/providers/aws/environments/prod/12-vercel/main.tf
+++ b/providers/aws/environments/prod/12-vercel/main.tf
@@ -1,0 +1,6 @@
+module "vercel_domains_apex" {
+  source           = "../../../../../modules/aws/vercel/domains/apex"
+  main_host_zone   = data.aws_route53_zone.main_host_zone.zone_id
+  main_domain_name = var.main_domain_name
+  a_record_value   = local.a_record_value
+}

--- a/providers/aws/environments/prod/12-vercel/provider.tf
+++ b/providers/aws/environments/prod/12-vercel/provider.tf
@@ -1,0 +1,4 @@
+provider "aws" {
+  region  = "ap-northeast-1"
+  profile = "lgtm-cat"
+}

--- a/providers/aws/environments/prod/12-vercel/variables.tf
+++ b/providers/aws/environments/prod/12-vercel/variables.tf
@@ -1,0 +1,12 @@
+locals {
+  a_record_value = "76.76.21.21"
+}
+
+variable "main_domain_name" {
+  type    = string
+  default = "lgtmeow.com"
+}
+
+data "aws_route53_zone" "main_host_zone" {
+  name = var.main_domain_name
+}

--- a/providers/aws/environments/prod/12-vercel/versions.tf
+++ b/providers/aws/environments/prod/12-vercel/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = "0.14.7"
+
+  required_providers {
+    aws = "3.29.0"
+  }
+}

--- a/terraform-init.sh
+++ b/terraform-init.sh
@@ -3,6 +3,7 @@
 tfstateDirList='
 /data/providers/aws/environments/prod/10-acm
 /data/providers/aws/environments/prod/11-images
+/data/providers/aws/environments/prod/12-vercel
 '
 
 for tfstateDir in ${tfstateDirList}; do


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-frontend/issues/5

# 関連URL
https://lgtmeow.com

# Doneの定義
- https://github.com/nekochans/lgtm-cat-frontend がVercel上にデプロイされ独自ドメインで接続出来るようになっている事

# 変更点概要
https://vercel.com/docs/custom-domains#apex-domains に従いAレコードを追加。

ちなみに `modules/aws/vercel/domains/apex/` のように階層構造を持つようなディレクトリ構成になっている。

これは今回追加したApexDomainの設定方法とサブドメインの設定方法が異なるから為、ステージング環境や開発環境作成時には `modules/aws/vercel/domains/sub/` を作成する予定。

# 補足情報
Vercelが自動で設定するドメイン https://lgtm-cat-frontend.vercel.app があるがこれに関しては https://lgtmeow.com に301リダイレクトするように設定してあるので、SEO的に重複コンテンツ等のリスクはないと思われる。

https://github.com/nekochans/lgtm-cat-frontend/issues/5 の完了の定義に「Google検索に引っかからないようにnoindexの設定が追加されている事」があるが、よく考えたら現在はSEO対策も宣伝も何もやっていないので、無理にnoindexの設定をやらなくても問題はないと考えnoindexの設定は行っていない。