### PR TITLE
Route 53のTXTレコードを管理する為のModuleを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: ci
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  terraform:
+    name: Terraform
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    defaults:
+      run:
+        shell: bash
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v1
+      with:
+        terraform_version: 0.14.5
+
+    - name: Terraform Format
+      run: terraform fmt -recursive -check

--- a/README.md
+++ b/README.md
@@ -82,6 +82,16 @@ aws_secret_access_key = あなたのシークレットアクセスキー
 
 この設定は `providers/aws/environments/○○/backend.tf` に記載されています。
 
+### 環境変数用ファイルの配置
+
+以下のファイルを配置して下さい。
+
+#### providers/aws/environments/prod/13-txt/terraform.tfvars
+
+```terraform
+txt_records = ["google-site-verification=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"]
+```
+
 ### 初期化
 
 Docker起動後にホストOS上で以下のコマンドを実行すると `terraform init` が実行されます。

--- a/modules/aws/txt/main.tf
+++ b/modules/aws/txt/main.tf
@@ -1,0 +1,7 @@
+resource "aws_route53_record" "txt_records" {
+  name    = var.main_domain_name
+  type    = "TXT"
+  zone_id = var.main_host_zone
+  records = var.txt_records
+  ttl     = "300"
+}

--- a/modules/aws/txt/variables.tf
+++ b/modules/aws/txt/variables.tf
@@ -1,0 +1,13 @@
+variable "main_host_zone" {
+  type = string
+}
+
+variable "main_domain_name" {
+  type = string
+}
+
+variable "txt_records" {
+  type = list(string)
+
+  default = []
+}

--- a/providers/aws/environments/prod/13-txt/.terraform.lock.hcl
+++ b/providers/aws/environments/prod/13-txt/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.29.0"
+  constraints = "3.29.0"
+  hashes = [
+    "h1:euXiL7Q/8CZ7eFO8ktcDVNEV51tJpicreQGazmNSGCg=",
+    "zh:0e3ec82025efcfed94180858240a1be147bc3eabb24a755f8c58970173b71e54",
+    "zh:22897ef5b00317ffa2495a5582c567a4ceca09e9071e0888b18c8364bab6d31b",
+    "zh:2e98fc511787045e5ef6f0e76d92ea8de27cd168b20902f9e57d75c96dcb80d8",
+    "zh:4e86f7f25c27c139ae17e3ad2a82a154b115d83f16bf8d8fee2aba9f00c80437",
+    "zh:71ba0b2b10a5e83b276ebca1d8559354c12656310bfd2554591ac6f0f5541bd0",
+    "zh:771989dadb5921bf4586c749a537116eaafdd854e542c5890c9dac55d7b2f8ac",
+    "zh:7aa3095c12174b6f8f525ba6007312df6b95de4b4137d25414144e7731ac202c",
+    "zh:a1c6f9a6f1abee0cc9c4a3a912c0e6571e7cc439701f03172de44b4187e66769",
+    "zh:bd50937e68e9434fc482817e9acfe486b95c69494194627884091a0581a0dffd",
+    "zh:e035fd1df86f709374a8547ac141edd1bd899cc7d979b7b28da3ad62fa6ff47b",
+  ]
+}

--- a/providers/aws/environments/prod/13-txt/backend.tf
+++ b/providers/aws/environments/prod/13-txt/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket  = "lgtm-cat-tfstate"
+    key     = "txt/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "lgtm-cat"
+  }
+}

--- a/providers/aws/environments/prod/13-txt/main.tf
+++ b/providers/aws/environments/prod/13-txt/main.tf
@@ -1,0 +1,6 @@
+module "txt" {
+  source           = "../../../../../modules/aws/txt"
+  main_host_zone   = data.aws_route53_zone.main_host_zone.zone_id
+  main_domain_name = var.main_domain_name
+  txt_records      = var.txt_records
+}

--- a/providers/aws/environments/prod/13-txt/provider.tf
+++ b/providers/aws/environments/prod/13-txt/provider.tf
@@ -1,0 +1,4 @@
+provider "aws" {
+  region  = "ap-northeast-1"
+  profile = "lgtm-cat"
+}

--- a/providers/aws/environments/prod/13-txt/variables.tf
+++ b/providers/aws/environments/prod/13-txt/variables.tf
@@ -1,0 +1,14 @@
+variable "main_domain_name" {
+  type    = string
+  default = "lgtmeow.com"
+}
+
+data "aws_route53_zone" "main_host_zone" {
+  name = var.main_domain_name
+}
+
+variable "txt_records" {
+  type = list(string)
+
+  default = []
+}

--- a/providers/aws/environments/prod/13-txt/versions.tf
+++ b/providers/aws/environments/prod/13-txt/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = "0.14.7"
+
+  required_providers {
+    aws = "3.29.0"
+  }
+}

--- a/terraform-init.sh
+++ b/terraform-init.sh
@@ -4,6 +4,7 @@ tfstateDirList='
 /data/providers/aws/environments/prod/10-acm
 /data/providers/aws/environments/prod/11-images
 /data/providers/aws/environments/prod/12-vercel
+/data/providers/aws/environments/prod/13-txt
 '
 
 for tfstateDir in ${tfstateDirList}; do


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-terraform/issues/6

# Doneの定義
- Route 53のTXTレコードが管理出来るようになっている事
- Google Search Consoleのドメイン確認用TXTレコードが追加されている事

# 変更点概要
`13-txt` を追加して、TXTレコードを管理出来るようにした。

TXTレコードはフロントエンドでもバックエンドでも利用する可能性があるので、別のtfstateとして独立させたほうが良いと判断した。

# レビュアーに重点的にチェックして欲しい点

`13-txt` の名前でもっと良い案があれば教えて欲しい:pray:

# 補足情報

Google Search Consoleは利用可能になっており、XMLサイトマップのURLも送信済。

![search-console](https://user-images.githubusercontent.com/11032365/110084928-d9c3ee80-7dd3-11eb-91fa-7bb9ec263bd2.png)

![send-sitemap](https://user-images.githubusercontent.com/11032365/110085681-bd748180-7dd4-11eb-85e8-2cad532466cb.png)