### PR TITLE
LGTM画像になる前の一時的な画像を扱う為のS3バケットを作成

### DIFF
--- a/modules/aws/images/main.tf
+++ b/modules/aws/images/main.tf
@@ -1,3 +1,25 @@
+resource "aws_s3_bucket" "upload_images_bucket" {
+  bucket = var.upload_images_bucket_name
+  acl    = "private"
+
+  force_destroy = true
+
+  versioning {
+    enabled = true
+  }
+
+  lifecycle_rule {
+    enabled = true
+    // 失効した削除マーカーまたは不完全なマルチパートアップロードを削除する
+    abort_incomplete_multipart_upload_days = 7
+
+    // 古いバージョンは30日で削除
+    noncurrent_version_expiration {
+      days = 30
+    }
+  }
+}
+
 resource "aws_s3_bucket" "lgtm_images_bucket" {
   bucket = var.lgtm_images_bucket_name
   acl    = "private"

--- a/modules/aws/images/outputs.tf
+++ b/modules/aws/images/outputs.tf
@@ -1,3 +1,7 @@
+output "upload_images_bucket_name" {
+  value = aws_s3_bucket.upload_images_bucket.bucket
+}
+
 output "lgtm_images_bucket_name" {
   value = aws_s3_bucket.lgtm_images_bucket.bucket
 }

--- a/modules/aws/images/variables.tf
+++ b/modules/aws/images/variables.tf
@@ -1,3 +1,7 @@
+variable "upload_images_bucket_name" {
+  type = string
+}
+
 variable "lgtm_images_bucket_name" {
   type = string
 }

--- a/providers/aws/environments/prod/11-images/main.tf
+++ b/providers/aws/environments/prod/11-images/main.tf
@@ -5,4 +5,5 @@ module "images" {
   lgtm_images_cdn_domain     = local.lgtm_images_cdn_domain
   lgtm_images_cdn_acm_arn    = local.lgtm_images_cdn_acm_arn
   main_host_zone             = data.aws_route53_zone.main_host_zone.zone_id
+  upload_images_bucket_name  = local.upload_images_bucket_name
 }

--- a/providers/aws/environments/prod/11-images/outputs.tf
+++ b/providers/aws/environments/prod/11-images/outputs.tf
@@ -1,3 +1,7 @@
+output "upload_images_bucket_name" {
+  value = module.images.upload_images_bucket_name
+}
+
 output "lgtm_images_bucket_name" {
   value = module.images.lgtm_images_bucket_name
 }

--- a/providers/aws/environments/prod/11-images/variables.tf
+++ b/providers/aws/environments/prod/11-images/variables.tf
@@ -6,6 +6,7 @@ locals {
   lgtm_images_cdn_domain     = "${local.lgtm_images_cdn_sub_domain}.${var.main_domain_name}"
   lgtm_images_cdn_acm_arn    = data.terraform_remote_state.acm.outputs.us_east_1_sub_domain_acm_arn
   main_host_zone             = data.aws_route53_zone.main_host_zone
+  upload_images_bucket_name  = "${local.env}-${local.name}-upload-images"
 }
 
 variable "main_domain_name" {


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-terraform/issues/12

# Doneの定義
- https://github.com/nekochans/lgtm-cat-terraform/issues/12 の完了の定義を満たしている事

# 変更点概要
表題の通り、LGTM画像になる前の一時的な画像を扱う為のS3バケットを作成。

名前は `prod-lgtmeow-upload-images` 、このS3バケットには以下の3つのディレクトリを作成してある。

| dirName     | description                                                                                                                                                        |
|-------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| uploaded    | https://github.com/nekochans/lgtm-cat-api/issues/2 で作成されるAPIによって画像がここに格納される                                                            |
| cat-images  | uploaded にuploadされた画像が https://github.com/nekochans/lgtm-cat-image-recognition によって検査され、ねこ画像と判定された画像のみがこのディレクトリに格納される |
| lgtm-images | cat-images に格納された画像を https://github.com/nekochans/lgtm-cat-lambda/issues/2 のLambda関数でLGTM画像化した物がこのディレクトリに格納される                   |

`lgtm-images` ディレクトリに格納されたLGTM画像は https://github.com/nekochans/convert-to-webp によってWebpに変換され、現在画像配信に利用している `prod-lgtmeow-images` に移動される。その後、https://github.com/nekochans/lgtm-cat-lambda/issues/3  で作成されるLambda関数によってRDSに必要な情報が記録される。

# レビュアーに重点的にチェックして欲しい点
ディレクトリ名とその役割、画像がアップロードされてから、最終的にLGTM画像として配信されるまでの流れに関して問題ないか確認をしてもらえるとありがたい:pray: