### PR TITLE
アップロード機能に必要なS3バケットの作成と設定変更

### DIFF
--- a/modules/aws/images/main.tf
+++ b/modules/aws/images/main.tf
@@ -20,6 +20,40 @@ resource "aws_s3_bucket" "upload_images_bucket" {
   }
 }
 
+resource "aws_s3_bucket" "cat_images_bucket" {
+  bucket = var.cat_images_bucket_name
+  acl    = "private"
+
+  force_destroy = true
+
+  versioning {
+    enabled = false
+  }
+
+  lifecycle_rule {
+    enabled = true
+    // 失効した削除マーカーまたは不完全なマルチパートアップロードを削除する
+    abort_incomplete_multipart_upload_days = 7
+  }
+}
+
+resource "aws_s3_bucket" "created_lgtm_images_bucket" {
+  bucket = var.created_lgtm_images_bucket_name
+  acl    = "private"
+
+  force_destroy = true
+
+  versioning {
+    enabled = false
+  }
+
+  lifecycle_rule {
+    enabled = true
+    // 失効した削除マーカーまたは不完全なマルチパートアップロードを削除する
+    abort_incomplete_multipart_upload_days = 7
+  }
+}
+
 resource "aws_s3_bucket" "lgtm_images_bucket" {
   bucket = var.lgtm_images_bucket_name
   acl    = "private"

--- a/modules/aws/images/main.tf
+++ b/modules/aws/images/main.tf
@@ -5,18 +5,13 @@ resource "aws_s3_bucket" "upload_images_bucket" {
   force_destroy = true
 
   versioning {
-    enabled = true
+    enabled = false
   }
 
   lifecycle_rule {
     enabled = true
     // 失効した削除マーカーまたは不完全なマルチパートアップロードを削除する
     abort_incomplete_multipart_upload_days = 7
-
-    // 古いバージョンは30日で削除
-    noncurrent_version_expiration {
-      days = 30
-    }
   }
 }
 

--- a/modules/aws/images/outputs.tf
+++ b/modules/aws/images/outputs.tf
@@ -2,6 +2,14 @@ output "upload_images_bucket_name" {
   value = aws_s3_bucket.upload_images_bucket.bucket
 }
 
+output "cat_images_bucket_name" {
+  value = aws_s3_bucket.cat_images_bucket.bucket
+}
+
+output "created_lgtm_images_bucket_name" {
+  value = aws_s3_bucket.created_lgtm_images_bucket.bucket
+}
+
 output "lgtm_images_bucket_name" {
   value = aws_s3_bucket.lgtm_images_bucket.bucket
 }

--- a/modules/aws/images/variables.tf
+++ b/modules/aws/images/variables.tf
@@ -2,6 +2,14 @@ variable "upload_images_bucket_name" {
   type = string
 }
 
+variable "cat_images_bucket_name" {
+  type = string
+}
+
+variable "created_lgtm_images_bucket_name" {
+  type = string
+}
+
 variable "lgtm_images_bucket_name" {
   type = string
 }

--- a/providers/aws/environments/prod/11-images/main.tf
+++ b/providers/aws/environments/prod/11-images/main.tf
@@ -1,9 +1,11 @@
 module "images" {
-  source                     = "../../../../../modules/aws/images"
-  lgtm_images_bucket_name    = local.lgtm_images_bucket_name
-  lgtm_images_cdn_sub_domain = local.lgtm_images_cdn_sub_domain
-  lgtm_images_cdn_domain     = local.lgtm_images_cdn_domain
-  lgtm_images_cdn_acm_arn    = local.lgtm_images_cdn_acm_arn
-  main_host_zone             = data.aws_route53_zone.main_host_zone.zone_id
-  upload_images_bucket_name  = local.upload_images_bucket_name
+  source                          = "../../../../../modules/aws/images"
+  lgtm_images_bucket_name         = local.lgtm_images_bucket_name
+  lgtm_images_cdn_sub_domain      = local.lgtm_images_cdn_sub_domain
+  lgtm_images_cdn_domain          = local.lgtm_images_cdn_domain
+  lgtm_images_cdn_acm_arn         = local.lgtm_images_cdn_acm_arn
+  main_host_zone                  = data.aws_route53_zone.main_host_zone.zone_id
+  upload_images_bucket_name       = local.upload_images_bucket_name
+  cat_images_bucket_name          = local.cat_images_bucket_name
+  created_lgtm_images_bucket_name = local.created_lgtm_images_bucket_name
 }

--- a/providers/aws/environments/prod/11-images/variables.tf
+++ b/providers/aws/environments/prod/11-images/variables.tf
@@ -1,12 +1,14 @@
 locals {
-  env                        = "prod"
-  name                       = "lgtmeow"
-  lgtm_images_bucket_name    = "${local.env}-${local.name}-images"
-  lgtm_images_cdn_sub_domain = "lgtm-images"
-  lgtm_images_cdn_domain     = "${local.lgtm_images_cdn_sub_domain}.${var.main_domain_name}"
-  lgtm_images_cdn_acm_arn    = data.terraform_remote_state.acm.outputs.us_east_1_sub_domain_acm_arn
-  main_host_zone             = data.aws_route53_zone.main_host_zone
-  upload_images_bucket_name  = "${local.env}-${local.name}-upload-images"
+  env                             = "prod"
+  name                            = "lgtmeow"
+  lgtm_images_bucket_name         = "${local.env}-${local.name}-images"
+  lgtm_images_cdn_sub_domain      = "lgtm-images"
+  lgtm_images_cdn_domain          = "${local.lgtm_images_cdn_sub_domain}.${var.main_domain_name}"
+  lgtm_images_cdn_acm_arn         = data.terraform_remote_state.acm.outputs.us_east_1_sub_domain_acm_arn
+  main_host_zone                  = data.aws_route53_zone.main_host_zone
+  upload_images_bucket_name       = "${local.env}-${local.name}-upload-images"
+  cat_images_bucket_name          = "${local.env}-${local.name}-cat-images"
+  created_lgtm_images_bucket_name = "${local.env}-${local.name}-created-lgtm-images"
 }
 
 variable "main_domain_name" {


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-terraform/issues/18

# Doneの定義
- https://github.com/nekochans/lgtm-cat-terraform/issues/18 の完了の定義を満たしている事

# 変更点概要
以下の2つのバケットを新規作成。

- prod-lgtmeow-cat-images（nekochans/lgtm-cat-api#2 で作成したAPIでこのS3バケットに画像をアップロードする、ディレクトリ構成は YYYY/MM/DD/HH/UUID形式の文字列.jpg みたいな感じで保存する）
- prod-lgtmeow-created-lgtm-images（nekochans/lgtm-cat-lambda#2 で作成したLGTM画像を格納する、移動させる際は prod-lgtmeow-upload-images のディレクトリ階層を維持したまま移動させる）

また、prod-lgtmeow-upload-images（今既にあるバケット）のバージョニング設定を無効化、これは一時的な画像には有効期限を持たせたいが、バージョニングが有効になっていると画像に有効期限を持たせられない為である。

# レビュアーに重点的にチェックして欲しい点
[Slackで相談した、S3バケットを分割する件](https://nekochans.slack.com/archives/C01NSTL64Q0/p1617865613007800) の対応なんだけど、問題ある場合は修正するから確認してもらえると:pray: