### PR TITLE
バックエンド環境用のステージング環境を構築

### DIFF
--- a/providers/aws/environments/stg/10-acm/.terraform.lock.hcl
+++ b/providers/aws/environments/stg/10-acm/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.29.0"
+  constraints = "3.29.0"
+  hashes = [
+    "h1:euXiL7Q/8CZ7eFO8ktcDVNEV51tJpicreQGazmNSGCg=",
+    "zh:0e3ec82025efcfed94180858240a1be147bc3eabb24a755f8c58970173b71e54",
+    "zh:22897ef5b00317ffa2495a5582c567a4ceca09e9071e0888b18c8364bab6d31b",
+    "zh:2e98fc511787045e5ef6f0e76d92ea8de27cd168b20902f9e57d75c96dcb80d8",
+    "zh:4e86f7f25c27c139ae17e3ad2a82a154b115d83f16bf8d8fee2aba9f00c80437",
+    "zh:71ba0b2b10a5e83b276ebca1d8559354c12656310bfd2554591ac6f0f5541bd0",
+    "zh:771989dadb5921bf4586c749a537116eaafdd854e542c5890c9dac55d7b2f8ac",
+    "zh:7aa3095c12174b6f8f525ba6007312df6b95de4b4137d25414144e7731ac202c",
+    "zh:a1c6f9a6f1abee0cc9c4a3a912c0e6571e7cc439701f03172de44b4187e66769",
+    "zh:bd50937e68e9434fc482817e9acfe486b95c69494194627884091a0581a0dffd",
+    "zh:e035fd1df86f709374a8547ac141edd1bd899cc7d979b7b28da3ad62fa6ff47b",
+  ]
+}

--- a/providers/aws/environments/stg/10-acm/backend.tf
+++ b/providers/aws/environments/stg/10-acm/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket  = "stg-lgtm-cat-tfstate"
+    key     = "acm/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "lgtm-cat"
+  }
+}

--- a/providers/aws/environments/stg/10-acm/main.tf
+++ b/providers/aws/environments/stg/10-acm/main.tf
@@ -1,0 +1,15 @@
+module "ap_northeast_1_acm" {
+  source = "../../../../../modules/aws/acm"
+
+  main_domain_name = local.main_domain_name
+}
+
+module "us_east_1_acm" {
+  source = "../../../../../modules/aws/acm"
+
+  main_domain_name = local.main_domain_name
+
+  providers = {
+    aws = aws.us-east-1
+  }
+}

--- a/providers/aws/environments/stg/10-acm/outputs.tf
+++ b/providers/aws/environments/stg/10-acm/outputs.tf
@@ -1,0 +1,15 @@
+output "ap_northeast_1_main_domain_acm_arn" {
+  value = module.ap_northeast_1_acm.main_domain_acm_arn
+}
+
+output "ap_northeast_1_sub_domain_acm_arn" {
+  value = module.ap_northeast_1_acm.sub_domain_acm_arn
+}
+
+output "us_east_1_main_domain_acm_arn" {
+  value = module.us_east_1_acm.main_domain_acm_arn
+}
+
+output "us_east_1_sub_domain_acm_arn" {
+  value = module.us_east_1_acm.sub_domain_acm_arn
+}

--- a/providers/aws/environments/stg/10-acm/provider.tf
+++ b/providers/aws/environments/stg/10-acm/provider.tf
@@ -1,0 +1,10 @@
+provider "aws" {
+  region  = "ap-northeast-1"
+  profile = "lgtm-cat"
+}
+
+provider "aws" {
+  region  = "us-east-1"
+  profile = "lgtm-cat"
+  alias   = "us-east-1"
+}

--- a/providers/aws/environments/stg/10-acm/variables.tf
+++ b/providers/aws/environments/stg/10-acm/variables.tf
@@ -1,0 +1,4 @@
+locals {
+  env              = "stg"
+  main_domain_name = "lgtmeow.com"
+}

--- a/providers/aws/environments/stg/10-acm/versions.tf
+++ b/providers/aws/environments/stg/10-acm/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = "0.14.7"
+
+  required_providers {
+    aws = "3.29.0"
+  }
+}

--- a/providers/aws/environments/stg/11-images/.terraform.lock.hcl
+++ b/providers/aws/environments/stg/11-images/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.29.0"
+  constraints = "3.29.0"
+  hashes = [
+    "h1:euXiL7Q/8CZ7eFO8ktcDVNEV51tJpicreQGazmNSGCg=",
+    "zh:0e3ec82025efcfed94180858240a1be147bc3eabb24a755f8c58970173b71e54",
+    "zh:22897ef5b00317ffa2495a5582c567a4ceca09e9071e0888b18c8364bab6d31b",
+    "zh:2e98fc511787045e5ef6f0e76d92ea8de27cd168b20902f9e57d75c96dcb80d8",
+    "zh:4e86f7f25c27c139ae17e3ad2a82a154b115d83f16bf8d8fee2aba9f00c80437",
+    "zh:71ba0b2b10a5e83b276ebca1d8559354c12656310bfd2554591ac6f0f5541bd0",
+    "zh:771989dadb5921bf4586c749a537116eaafdd854e542c5890c9dac55d7b2f8ac",
+    "zh:7aa3095c12174b6f8f525ba6007312df6b95de4b4137d25414144e7731ac202c",
+    "zh:a1c6f9a6f1abee0cc9c4a3a912c0e6571e7cc439701f03172de44b4187e66769",
+    "zh:bd50937e68e9434fc482817e9acfe486b95c69494194627884091a0581a0dffd",
+    "zh:e035fd1df86f709374a8547ac141edd1bd899cc7d979b7b28da3ad62fa6ff47b",
+  ]
+}

--- a/providers/aws/environments/stg/11-images/backend.tf
+++ b/providers/aws/environments/stg/11-images/backend.tf
@@ -1,0 +1,19 @@
+terraform {
+  backend "s3" {
+    bucket  = "stg-lgtm-cat-tfstate"
+    key     = "images/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "lgtm-cat"
+  }
+}
+
+data "terraform_remote_state" "acm" {
+  backend = "s3"
+
+  config = {
+    bucket  = "stg-lgtm-cat-tfstate"
+    key     = "acm/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "lgtm-cat"
+  }
+}

--- a/providers/aws/environments/stg/11-images/main.tf
+++ b/providers/aws/environments/stg/11-images/main.tf
@@ -1,0 +1,11 @@
+module "images" {
+  source                          = "../../../../../modules/aws/images"
+  lgtm_images_bucket_name         = local.lgtm_images_bucket_name
+  lgtm_images_cdn_sub_domain      = local.lgtm_images_cdn_sub_domain
+  lgtm_images_cdn_domain          = local.lgtm_images_cdn_domain
+  lgtm_images_cdn_acm_arn         = local.lgtm_images_cdn_acm_arn
+  main_host_zone                  = data.aws_route53_zone.main_host_zone.zone_id
+  upload_images_bucket_name       = local.upload_images_bucket_name
+  cat_images_bucket_name          = local.cat_images_bucket_name
+  created_lgtm_images_bucket_name = local.created_lgtm_images_bucket_name
+}

--- a/providers/aws/environments/stg/11-images/outputs.tf
+++ b/providers/aws/environments/stg/11-images/outputs.tf
@@ -1,0 +1,7 @@
+output "upload_images_bucket_name" {
+  value = module.images.upload_images_bucket_name
+}
+
+output "lgtm_images_bucket_name" {
+  value = module.images.lgtm_images_bucket_name
+}

--- a/providers/aws/environments/stg/11-images/provider.tf
+++ b/providers/aws/environments/stg/11-images/provider.tf
@@ -1,0 +1,4 @@
+provider "aws" {
+  region  = "ap-northeast-1"
+  profile = "lgtm-cat"
+}

--- a/providers/aws/environments/stg/11-images/variables.tf
+++ b/providers/aws/environments/stg/11-images/variables.tf
@@ -1,0 +1,21 @@
+locals {
+  env                             = "stg"
+  name                            = "lgtmeow"
+  lgtm_images_bucket_name         = "${local.env}-${local.name}-images"
+  lgtm_images_cdn_sub_domain      = "${local.env}-lgtm-images"
+  lgtm_images_cdn_domain          = "${local.lgtm_images_cdn_sub_domain}.${var.main_domain_name}"
+  lgtm_images_cdn_acm_arn         = data.terraform_remote_state.acm.outputs.us_east_1_sub_domain_acm_arn
+  main_host_zone                  = data.aws_route53_zone.main_host_zone
+  upload_images_bucket_name       = "${local.env}-${local.name}-upload-images"
+  cat_images_bucket_name          = "${local.env}-${local.name}-cat-images"
+  created_lgtm_images_bucket_name = "${local.env}-${local.name}-created-lgtm-images"
+}
+
+variable "main_domain_name" {
+  type    = string
+  default = "lgtmeow.com"
+}
+
+data "aws_route53_zone" "main_host_zone" {
+  name = var.main_domain_name
+}

--- a/providers/aws/environments/stg/11-images/versions.tf
+++ b/providers/aws/environments/stg/11-images/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = "0.14.7"
+
+  required_providers {
+    aws = "3.29.0"
+  }
+}

--- a/terraform-init.sh
+++ b/terraform-init.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 
 tfstateDirList='
+/data/providers/aws/environments/stg/10-acm
+/data/providers/aws/environments/stg/11-images
 /data/providers/aws/environments/prod/10-acm
 /data/providers/aws/environments/prod/11-images
 /data/providers/aws/environments/prod/12-vercel


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-terraform/issues/21

# Doneの定義
- https://github.com/nekochans/lgtm-cat-terraform/issues/21 の完了の定義を満たしている事

# 変更点概要

作成したのは画像作成用のS3バケットと画像配信用のCloudFrontのみ、という訳で以下のリソースを用意。

以下の2つを用意。

- providers/aws/environments/stg/10-acm
- providers/aws/environments/stg/11-images

ステージング用の `tfstate` を保存するS3バケット `stg-lgtm-cat-tfstate` を手動で作成してある。

バックエンドの処理をステージングで動作確認出来るようにするのが目的なのでこれで問題ないハズ。