### PR TITLE
Serverlessデプロイ用のIAMユーザーを作成

### DIFF
--- a/modules/aws/iam/files/policy/serverless-deploy-policy.json
+++ b/modules/aws/iam/files/policy/serverless-deploy-policy.json
@@ -1,0 +1,81 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iam:*"
+      ],
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "cognito-identity:*",
+        "cognito-sync:*",
+        "cognito-idp:*"
+      ],
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": "lambda:*",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": "cloudformation:*",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": "s3:*",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": "logs:*",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": "sts:*",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": "apigateway:*",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": "events:*",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": "cloudfront:*",
+      "Resource": [
+        "*"
+      ]
+    }
+  ]
+}

--- a/modules/aws/iam/main.tf
+++ b/modules/aws/iam/main.tf
@@ -1,0 +1,15 @@
+resource "aws_iam_user" "serverless_deploy_user" {
+  name          = var.serverless_deploy_user_name
+  force_destroy = true
+}
+
+resource "aws_iam_policy" "serverless_deploy_policy" {
+  name        = "${var.serverless_deploy_user_name}-policy"
+  description = "${var.serverless_deploy_user_name}-policy"
+  policy      = file("../../../../../modules/aws/iam/files/policy/serverless-deploy-policy.json")
+}
+
+resource "aws_iam_user_policy_attachment" "serverless_deploy_policy_attach" {
+  user       = aws_iam_user.serverless_deploy_user.name
+  policy_arn = aws_iam_policy.serverless_deploy_policy.arn
+}

--- a/modules/aws/iam/variables.tf
+++ b/modules/aws/iam/variables.tf
@@ -1,0 +1,3 @@
+variable "serverless_deploy_user_name" {
+  type = string
+}

--- a/providers/aws/environments/prod/14-iam/.terraform.lock.hcl
+++ b/providers/aws/environments/prod/14-iam/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.29.0"
+  constraints = "3.29.0"
+  hashes = [
+    "h1:euXiL7Q/8CZ7eFO8ktcDVNEV51tJpicreQGazmNSGCg=",
+    "zh:0e3ec82025efcfed94180858240a1be147bc3eabb24a755f8c58970173b71e54",
+    "zh:22897ef5b00317ffa2495a5582c567a4ceca09e9071e0888b18c8364bab6d31b",
+    "zh:2e98fc511787045e5ef6f0e76d92ea8de27cd168b20902f9e57d75c96dcb80d8",
+    "zh:4e86f7f25c27c139ae17e3ad2a82a154b115d83f16bf8d8fee2aba9f00c80437",
+    "zh:71ba0b2b10a5e83b276ebca1d8559354c12656310bfd2554591ac6f0f5541bd0",
+    "zh:771989dadb5921bf4586c749a537116eaafdd854e542c5890c9dac55d7b2f8ac",
+    "zh:7aa3095c12174b6f8f525ba6007312df6b95de4b4137d25414144e7731ac202c",
+    "zh:a1c6f9a6f1abee0cc9c4a3a912c0e6571e7cc439701f03172de44b4187e66769",
+    "zh:bd50937e68e9434fc482817e9acfe486b95c69494194627884091a0581a0dffd",
+    "zh:e035fd1df86f709374a8547ac141edd1bd899cc7d979b7b28da3ad62fa6ff47b",
+  ]
+}

--- a/providers/aws/environments/prod/14-iam/backend.tf
+++ b/providers/aws/environments/prod/14-iam/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket  = "lgtm-cat-tfstate"
+    key     = "iam/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "lgtm-cat"
+  }
+}

--- a/providers/aws/environments/prod/14-iam/main.tf
+++ b/providers/aws/environments/prod/14-iam/main.tf
@@ -1,0 +1,4 @@
+module "iam" {
+  source                      = "../../../../../modules/aws/iam"
+  serverless_deploy_user_name = local.serverless_deploy_user_name
+}

--- a/providers/aws/environments/prod/14-iam/provider.tf
+++ b/providers/aws/environments/prod/14-iam/provider.tf
@@ -1,0 +1,4 @@
+provider "aws" {
+  region  = "ap-northeast-1"
+  profile = "lgtm-cat"
+}

--- a/providers/aws/environments/prod/14-iam/variables.tf
+++ b/providers/aws/environments/prod/14-iam/variables.tf
@@ -1,0 +1,4 @@
+locals {
+  env                         = "prod"
+  serverless_deploy_user_name = "${local.env}-serverless-deploy"
+}

--- a/providers/aws/environments/prod/14-iam/versions.tf
+++ b/providers/aws/environments/prod/14-iam/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = "0.14.7"
+
+  required_providers {
+    aws = "3.29.0"
+  }
+}

--- a/terraform-init.sh
+++ b/terraform-init.sh
@@ -7,6 +7,7 @@ tfstateDirList='
 /data/providers/aws/environments/prod/11-images
 /data/providers/aws/environments/prod/12-vercel
 /data/providers/aws/environments/prod/13-txt
+/data/providers/aws/environments/prod/14-iam
 '
 
 for tfstateDir in ${tfstateDirList}; do


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-terraform/issues/14

# Doneの定義
- Serverlessデプロイ用のIAMユーザーが作成されている事

# 変更点概要
`providers/aws/environments/prod/14-iam/` を追加し `serverless deploy` で利用する為のIAMユーザーを作成。

IAMポリシーは [こちらの記事](https://dev.classmethod.jp/articles/iam-access-analyzer-easier-implement-least-privilege-permissions-generating-iam-policies-access-activity-2/) にある通り、admin権限を持ったIAMユーザーで実際に `serverless deploy` を実行した履歴を元に作成。

ただし、いくつかの権限に関しては手動で追加している。（対象箇所のインラインコメントを参照）

動作確認は以下の2つで行った。

- https://github.com/nekochans/convert-to-webp
- https://github.com/nekochans/lgtm-cat-image-recognition

# レビュアーに重点的にチェックして欲しい点

多分これでも、無駄な権限はあるけど、`AdministratorAccess` をアタッチするよりはマシだと思う🐱

ポリシーの内容見て問題ないか確認してもらえると:pray:

今後必要な権限が増えたら `serverless-deploy-policy.json` に追加していく感じで良いと思う！

# 補足情報

複数のリポジトリで利用するので以下の名前で `organizations secret` として追加済。

- LGTM_CAT_SERVERLESS_DEPLOY_AWS_ACCESS_KEY_ID
- LGTM_CAT_SERVERLESS_DEPLOY_AWS_SECRET_ACCESS_KEY