### PR TITLE
S3バケットのオブジェクトに有効期限を設定するルールを追加

### DIFF
--- a/modules/aws/images/main.tf
+++ b/modules/aws/images/main.tf
@@ -12,6 +12,11 @@ resource "aws_s3_bucket" "upload_images_bucket" {
     enabled = true
     // 失効した削除マーカーまたは不完全なマルチパートアップロードを削除する
     abort_incomplete_multipart_upload_days = 7
+
+    // オブジェクトの有効期限
+    expiration {
+      days = 10
+    }
   }
 }
 
@@ -29,6 +34,11 @@ resource "aws_s3_bucket" "cat_images_bucket" {
     enabled = true
     // 失効した削除マーカーまたは不完全なマルチパートアップロードを削除する
     abort_incomplete_multipart_upload_days = 7
+
+    // オブジェクトの有効期限
+    expiration {
+      days = 10
+    }
   }
 }
 
@@ -46,6 +56,11 @@ resource "aws_s3_bucket" "created_lgtm_images_bucket" {
     enabled = true
     // 失効した削除マーカーまたは不完全なマルチパートアップロードを削除する
     abort_incomplete_multipart_upload_days = 7
+
+    // オブジェクトの有効期限
+    expiration {
+      days = 10
+    }
   }
 }
 

--- a/modules/aws/images/main.tf
+++ b/modules/aws/images/main.tf
@@ -11,7 +11,7 @@ resource "aws_s3_bucket" "upload_images_bucket" {
   lifecycle_rule {
     enabled = true
     // 失効した削除マーカーまたは不完全なマルチパートアップロードを削除する
-    abort_incomplete_multipart_upload_days = 7
+    abort_incomplete_multipart_upload_days = 1
 
     // オブジェクトの有効期限
     expiration {
@@ -33,7 +33,7 @@ resource "aws_s3_bucket" "cat_images_bucket" {
   lifecycle_rule {
     enabled = true
     // 失効した削除マーカーまたは不完全なマルチパートアップロードを削除する
-    abort_incomplete_multipart_upload_days = 7
+    abort_incomplete_multipart_upload_days = 1
 
     // オブジェクトの有効期限
     expiration {
@@ -55,7 +55,7 @@ resource "aws_s3_bucket" "created_lgtm_images_bucket" {
   lifecycle_rule {
     enabled = true
     // 失効した削除マーカーまたは不完全なマルチパートアップロードを削除する
-    abort_incomplete_multipart_upload_days = 7
+    abort_incomplete_multipart_upload_days = 1
 
     // オブジェクトの有効期限
     expiration {


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-terraform/issues/24

# Doneの定義
- 一時的に画像が保存されるS3バケットのオブジェクトに有効期限が設定されている事

# 変更点概要
バージョニングが無効になっているS3バケットに対してオブジェクトの有効期限を設定。

これによって永続化が不要な画像ファイルは有効期限が来たら自動的に削除されるようになった。

検証用に `stg-lgtmeow-upload-images` に `test/test-cat1.png` を追加。

この画像が以下のようになっているので、設定は問題なく出来ている認識。

![test](https://user-images.githubusercontent.com/11032365/116841934-b079e000-ac15-11eb-9c69-2020556a4226.png)

# レビュアーに重点的にチェックして欲しい点
期待する動作としては、有効期限が過ぎたオブジェクトはS3バケットから完全に削除されて欲しいんだけど、設定方法がこれで合っているか確認してもらえると:pray: