### PR TITLE
アクセストークンを発行する用のCognitoUserPoolを作成

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,12 @@ lgtm-cat-terraform/
 
 今後このプロジェクトをベースに機能を追加する際も依存関係を意識してディレクトリ名を決める必要があります。
 
+[LGTMeow](https://lgtmeow.com) では本番環境とステージング環境など、その他の環境も同じAWSアカウント上にリソースが存在します。
+
+その為、AWSアカウントに1つだけ存在すれば良いリソースに関しては `providers/aws/environments/prod` にのみ定義されている場合があります。
+
+ステージング用のリソースが本番用のリソースに依存しているケースもあるので、先に本番用の `providers/aws/environments/prod` 配下の `terraform apply` を全て終わらせておく必要があります。
+
 ## 設計方針
 
 - 今はAWSのみだが、他のproviderが増えても大丈夫なように `providers/` を作ってあります

--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ aws_secret_access_key = あなたのシークレットアクセスキー
 txt_records = ["google-site-verification=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"]
 ```
 
+#### providers/aws/environments/prod/15-ses/terraform.tfvars
+
+```terraform
+from_email = "us-east-1のSES EmailAddressesに定義されているメールアドレスを指定"
+```
+
 ### 初期化
 
 Docker起動後にホストOS上で以下のコマンドを実行すると `terraform init` が実行されます。

--- a/modules/aws/cognito/main.tf
+++ b/modules/aws/cognito/main.tf
@@ -1,0 +1,82 @@
+resource "aws_cognito_user_pool" "user_pool" {
+  name                     = var.user_pool_name
+  auto_verified_attributes = ["email"]
+
+  admin_create_user_config {
+    allow_admin_create_user_only = false
+  }
+
+  username_attributes = ["email", "phone_number"]
+
+  password_policy {
+    minimum_length                   = 8
+    require_lowercase                = true
+    require_numbers                  = true
+    require_symbols                  = true
+    require_uppercase                = true
+    temporary_password_validity_days = 7
+  }
+
+  mfa_configuration = "OPTIONAL"
+
+  software_token_mfa_configuration {
+    enabled = true
+  }
+
+  verification_message_template {
+    default_email_option = "CONFIRM_WITH_CODE"
+    email_message        = "検証コードは {####} です。"
+    email_subject        = "検証コード"
+    sms_message          = "検証コードは {####} です。"
+  }
+
+  schema {
+    attribute_data_type      = "String"
+    developer_only_attribute = false
+    mutable                  = true
+    name                     = "email"
+    required                 = true
+
+    string_attribute_constraints {
+      min_length = 0
+      max_length = 2048
+    }
+  }
+
+  email_configuration {
+    source_arn            = var.email_identity_arn
+    email_sending_account = "DEVELOPER"
+  }
+}
+
+resource "aws_cognito_user_pool_domain" "user_pool_domain" {
+  domain       = var.user_pool_domain_name
+  user_pool_id = aws_cognito_user_pool.user_pool.id
+}
+
+// https://github.com/nekochans/lgtm-cat-api に定義されているAPIはこのscopeによって保護する
+resource "aws_cognito_resource_server" "lgtm_cat_api" {
+  name       = var.lgtm_cat_api_resource_server_name
+  identifier = var.lgtm_cat_api_resource_server_identifier
+
+  scope {
+    scope_description = "lgtm-cat-apiに定義されているAPIを全て利用出来る権限。"
+    scope_name        = "all"
+  }
+
+  user_pool_id = aws_cognito_user_pool.user_pool.id
+}
+
+// https://github.com/nekochans/lgtm-cat-frontend のサーバーサイド部分でのみ利用する
+resource "aws_cognito_user_pool_client" "lgtm_cat_bff_client" {
+  name                          = var.lgtm_cat_bff_client_name
+  user_pool_id                  = aws_cognito_user_pool.user_pool.id
+  generate_secret               = true
+  prevent_user_existence_errors = "ENABLED"
+
+  allowed_oauth_flows_user_pool_client = true
+  allowed_oauth_flows                  = ["client_credentials"]
+  allowed_oauth_scopes                 = ["${aws_cognito_resource_server.lgtm_cat_api.identifier}/all"]
+
+  depends_on = [aws_cognito_resource_server.lgtm_cat_api]
+}

--- a/modules/aws/cognito/variables.tf
+++ b/modules/aws/cognito/variables.tf
@@ -1,0 +1,23 @@
+variable "user_pool_name" {
+  type = string
+}
+
+variable "user_pool_domain_name" {
+  type = string
+}
+
+variable "email_identity_arn" {
+  type = string
+}
+
+variable "lgtm_cat_api_resource_server_name" {
+  type = string
+}
+
+variable "lgtm_cat_api_resource_server_identifier" {
+  type = string
+}
+
+variable "lgtm_cat_bff_client_name" {
+  type = string
+}

--- a/modules/aws/ses/main.tf
+++ b/modules/aws/ses/main.tf
@@ -1,0 +1,34 @@
+resource "aws_ses_domain_identity" "ses" {
+  domain = var.main_domain_name
+}
+
+data "aws_route53_zone" "main" {
+  name = var.main_domain_name
+}
+
+resource "aws_route53_record" "ses_txt_record" {
+  zone_id = data.aws_route53_zone.main.zone_id
+  name    = "_amazonses.${data.aws_route53_zone.main.name}"
+  type    = "TXT"
+  ttl     = "600"
+  records = [
+    aws_ses_domain_identity.ses.verification_token
+  ]
+}
+
+resource "aws_ses_domain_dkim" "dkim" {
+  domain = var.main_domain_name
+}
+
+resource "aws_route53_record" "dkim_record" {
+  count   = 3
+  zone_id = data.aws_route53_zone.main.zone_id
+  name    = "${element(aws_ses_domain_dkim.dkim.dkim_tokens, count.index)}._domainkey.${data.aws_route53_zone.main.name}"
+  type    = "CNAME"
+  ttl     = "600"
+  records = ["${element(aws_ses_domain_dkim.dkim.dkim_tokens, count.index)}.dkim.amazonses.com"]
+}
+
+resource "aws_ses_email_identity" "from_email" {
+  email = var.from_email
+}

--- a/modules/aws/ses/outputs.tf
+++ b/modules/aws/ses/outputs.tf
@@ -1,0 +1,3 @@
+output "email_identity_arn" {
+  value = aws_ses_email_identity.from_email.arn
+}

--- a/modules/aws/ses/variables.tf
+++ b/modules/aws/ses/variables.tf
@@ -1,0 +1,7 @@
+variable "main_domain_name" {
+  type = string
+}
+
+variable "from_email" {
+  type = string
+}

--- a/providers/aws/environments/prod/15-ses/.terraform.lock.hcl
+++ b/providers/aws/environments/prod/15-ses/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.29.0"
+  constraints = "3.29.0"
+  hashes = [
+    "h1:euXiL7Q/8CZ7eFO8ktcDVNEV51tJpicreQGazmNSGCg=",
+    "zh:0e3ec82025efcfed94180858240a1be147bc3eabb24a755f8c58970173b71e54",
+    "zh:22897ef5b00317ffa2495a5582c567a4ceca09e9071e0888b18c8364bab6d31b",
+    "zh:2e98fc511787045e5ef6f0e76d92ea8de27cd168b20902f9e57d75c96dcb80d8",
+    "zh:4e86f7f25c27c139ae17e3ad2a82a154b115d83f16bf8d8fee2aba9f00c80437",
+    "zh:71ba0b2b10a5e83b276ebca1d8559354c12656310bfd2554591ac6f0f5541bd0",
+    "zh:771989dadb5921bf4586c749a537116eaafdd854e542c5890c9dac55d7b2f8ac",
+    "zh:7aa3095c12174b6f8f525ba6007312df6b95de4b4137d25414144e7731ac202c",
+    "zh:a1c6f9a6f1abee0cc9c4a3a912c0e6571e7cc439701f03172de44b4187e66769",
+    "zh:bd50937e68e9434fc482817e9acfe486b95c69494194627884091a0581a0dffd",
+    "zh:e035fd1df86f709374a8547ac141edd1bd899cc7d979b7b28da3ad62fa6ff47b",
+  ]
+}

--- a/providers/aws/environments/prod/15-ses/backend.tf
+++ b/providers/aws/environments/prod/15-ses/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket  = "lgtm-cat-tfstate"
+    key     = "ses/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "lgtm-cat"
+  }
+}

--- a/providers/aws/environments/prod/15-ses/main.tf
+++ b/providers/aws/environments/prod/15-ses/main.tf
@@ -1,0 +1,5 @@
+module "ses" {
+  source           = "../../../../../modules/aws/ses"
+  main_domain_name = var.main_domain_name
+  from_email       = var.from_email
+}

--- a/providers/aws/environments/prod/15-ses/outputs.tf
+++ b/providers/aws/environments/prod/15-ses/outputs.tf
@@ -1,0 +1,3 @@
+output "email_identity_arn" {
+  value = module.ses.email_identity_arn
+}

--- a/providers/aws/environments/prod/15-ses/provider.tf
+++ b/providers/aws/environments/prod/15-ses/provider.tf
@@ -1,0 +1,4 @@
+provider "aws" {
+  region  = "us-east-1"
+  profile = "lgtm-cat"
+}

--- a/providers/aws/environments/prod/15-ses/variables.tf
+++ b/providers/aws/environments/prod/15-ses/variables.tf
@@ -1,0 +1,14 @@
+variable "main_domain_name" {
+  type    = string
+  default = "lgtmeow.com"
+}
+
+data "aws_route53_zone" "main_host_zone" {
+  name = var.main_domain_name
+}
+
+variable "from_email" {
+  type = string
+
+  default = ""
+}

--- a/providers/aws/environments/prod/15-ses/versions.tf
+++ b/providers/aws/environments/prod/15-ses/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = "0.14.7"
+
+  required_providers {
+    aws = "3.29.0"
+  }
+}

--- a/providers/aws/environments/prod/16-cognito/.terraform.lock.hcl
+++ b/providers/aws/environments/prod/16-cognito/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.29.0"
+  constraints = "3.29.0"
+  hashes = [
+    "h1:euXiL7Q/8CZ7eFO8ktcDVNEV51tJpicreQGazmNSGCg=",
+    "zh:0e3ec82025efcfed94180858240a1be147bc3eabb24a755f8c58970173b71e54",
+    "zh:22897ef5b00317ffa2495a5582c567a4ceca09e9071e0888b18c8364bab6d31b",
+    "zh:2e98fc511787045e5ef6f0e76d92ea8de27cd168b20902f9e57d75c96dcb80d8",
+    "zh:4e86f7f25c27c139ae17e3ad2a82a154b115d83f16bf8d8fee2aba9f00c80437",
+    "zh:71ba0b2b10a5e83b276ebca1d8559354c12656310bfd2554591ac6f0f5541bd0",
+    "zh:771989dadb5921bf4586c749a537116eaafdd854e542c5890c9dac55d7b2f8ac",
+    "zh:7aa3095c12174b6f8f525ba6007312df6b95de4b4137d25414144e7731ac202c",
+    "zh:a1c6f9a6f1abee0cc9c4a3a912c0e6571e7cc439701f03172de44b4187e66769",
+    "zh:bd50937e68e9434fc482817e9acfe486b95c69494194627884091a0581a0dffd",
+    "zh:e035fd1df86f709374a8547ac141edd1bd899cc7d979b7b28da3ad62fa6ff47b",
+  ]
+}

--- a/providers/aws/environments/prod/16-cognito/backend.tf
+++ b/providers/aws/environments/prod/16-cognito/backend.tf
@@ -1,0 +1,19 @@
+terraform {
+  backend "s3" {
+    bucket  = "lgtm-cat-tfstate"
+    key     = "cognito/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "lgtm-cat"
+  }
+}
+
+data "terraform_remote_state" "ses" {
+  backend = "s3"
+
+  config = {
+    bucket  = "lgtm-cat-tfstate"
+    key     = "ses/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "lgtm-cat"
+  }
+}

--- a/providers/aws/environments/prod/16-cognito/main.tf
+++ b/providers/aws/environments/prod/16-cognito/main.tf
@@ -1,0 +1,9 @@
+module "iam" {
+  source                                  = "../../../../../modules/aws/cognito"
+  user_pool_name                          = local.user_pool_name
+  user_pool_domain_name                   = local.user_pool_domain_name
+  email_identity_arn                      = local.email_identity_arn
+  lgtm_cat_api_resource_server_name       = local.lgtm_cat_api_resource_server_name
+  lgtm_cat_api_resource_server_identifier = local.lgtm_cat_api_resource_server_identifier
+  lgtm_cat_bff_client_name                = local.lgtm_cat_bff_client_name
+}

--- a/providers/aws/environments/prod/16-cognito/provider.tf
+++ b/providers/aws/environments/prod/16-cognito/provider.tf
@@ -1,0 +1,4 @@
+provider "aws" {
+  region  = "ap-northeast-1"
+  profile = "lgtm-cat"
+}

--- a/providers/aws/environments/prod/16-cognito/variables.tf
+++ b/providers/aws/environments/prod/16-cognito/variables.tf
@@ -1,0 +1,9 @@
+locals {
+  env                                     = "prod"
+  user_pool_name                          = "${local.env}-lgtmeow-user-pool"
+  user_pool_domain_name                   = "${local.env}-lgtmeow"
+  email_identity_arn                      = data.terraform_remote_state.ses.outputs.email_identity_arn
+  lgtm_cat_api_resource_server_name       = "${local.env}-lgtm-cat-api"
+  lgtm_cat_api_resource_server_identifier = "api.lgtmeow"
+  lgtm_cat_bff_client_name                = "lgtmeow-bff"
+}

--- a/providers/aws/environments/prod/16-cognito/versions.tf
+++ b/providers/aws/environments/prod/16-cognito/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = "0.14.7"
+
+  required_providers {
+    aws = "3.29.0"
+  }
+}

--- a/providers/aws/environments/stg/16-cognito/.terraform.lock.hcl
+++ b/providers/aws/environments/stg/16-cognito/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.29.0"
+  constraints = "3.29.0"
+  hashes = [
+    "h1:euXiL7Q/8CZ7eFO8ktcDVNEV51tJpicreQGazmNSGCg=",
+    "zh:0e3ec82025efcfed94180858240a1be147bc3eabb24a755f8c58970173b71e54",
+    "zh:22897ef5b00317ffa2495a5582c567a4ceca09e9071e0888b18c8364bab6d31b",
+    "zh:2e98fc511787045e5ef6f0e76d92ea8de27cd168b20902f9e57d75c96dcb80d8",
+    "zh:4e86f7f25c27c139ae17e3ad2a82a154b115d83f16bf8d8fee2aba9f00c80437",
+    "zh:71ba0b2b10a5e83b276ebca1d8559354c12656310bfd2554591ac6f0f5541bd0",
+    "zh:771989dadb5921bf4586c749a537116eaafdd854e542c5890c9dac55d7b2f8ac",
+    "zh:7aa3095c12174b6f8f525ba6007312df6b95de4b4137d25414144e7731ac202c",
+    "zh:a1c6f9a6f1abee0cc9c4a3a912c0e6571e7cc439701f03172de44b4187e66769",
+    "zh:bd50937e68e9434fc482817e9acfe486b95c69494194627884091a0581a0dffd",
+    "zh:e035fd1df86f709374a8547ac141edd1bd899cc7d979b7b28da3ad62fa6ff47b",
+  ]
+}

--- a/providers/aws/environments/stg/16-cognito/backend.tf
+++ b/providers/aws/environments/stg/16-cognito/backend.tf
@@ -1,0 +1,19 @@
+terraform {
+  backend "s3" {
+    bucket  = "stg-lgtm-cat-tfstate"
+    key     = "cognito/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "lgtm-cat"
+  }
+}
+
+data "terraform_remote_state" "ses" {
+  backend = "s3"
+
+  config = {
+    bucket  = "lgtm-cat-tfstate"
+    key     = "ses/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "lgtm-cat"
+  }
+}

--- a/providers/aws/environments/stg/16-cognito/main.tf
+++ b/providers/aws/environments/stg/16-cognito/main.tf
@@ -1,4 +1,4 @@
-module "iam" {
+module "cognito" {
   source                                  = "../../../../../modules/aws/cognito"
   user_pool_name                          = local.user_pool_name
   user_pool_domain_name                   = local.user_pool_domain_name

--- a/providers/aws/environments/stg/16-cognito/main.tf
+++ b/providers/aws/environments/stg/16-cognito/main.tf
@@ -1,0 +1,9 @@
+module "iam" {
+  source                                  = "../../../../../modules/aws/cognito"
+  user_pool_name                          = local.user_pool_name
+  user_pool_domain_name                   = local.user_pool_domain_name
+  email_identity_arn                      = local.email_identity_arn
+  lgtm_cat_api_resource_server_name       = local.lgtm_cat_api_resource_server_name
+  lgtm_cat_api_resource_server_identifier = local.lgtm_cat_api_resource_server_identifier
+  lgtm_cat_bff_client_name                = local.lgtm_cat_bff_client_name
+}

--- a/providers/aws/environments/stg/16-cognito/provider.tf
+++ b/providers/aws/environments/stg/16-cognito/provider.tf
@@ -1,0 +1,4 @@
+provider "aws" {
+  region  = "ap-northeast-1"
+  profile = "lgtm-cat"
+}

--- a/providers/aws/environments/stg/16-cognito/variables.tf
+++ b/providers/aws/environments/stg/16-cognito/variables.tf
@@ -1,0 +1,9 @@
+locals {
+  env                                     = "stg"
+  user_pool_name                          = "${local.env}-lgtmeow-user-pool"
+  user_pool_domain_name                   = "${local.env}-lgtmeow"
+  email_identity_arn                      = data.terraform_remote_state.ses.outputs.email_identity_arn
+  lgtm_cat_api_resource_server_name       = "${local.env}-lgtm-cat-api"
+  lgtm_cat_api_resource_server_identifier = "api.lgtmeow"
+  lgtm_cat_bff_client_name                = "lgtmeow-bff"
+}

--- a/providers/aws/environments/stg/16-cognito/versions.tf
+++ b/providers/aws/environments/stg/16-cognito/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = "0.14.7"
+
+  required_providers {
+    aws = "3.29.0"
+  }
+}

--- a/terraform-init.sh
+++ b/terraform-init.sh
@@ -1,8 +1,6 @@
 #!/bin/sh
 
 tfstateDirList='
-/data/providers/aws/environments/stg/10-acm
-/data/providers/aws/environments/stg/11-images
 /data/providers/aws/environments/prod/10-acm
 /data/providers/aws/environments/prod/11-images
 /data/providers/aws/environments/prod/12-vercel
@@ -10,6 +8,9 @@ tfstateDirList='
 /data/providers/aws/environments/prod/14-iam
 /data/providers/aws/environments/prod/15-ses
 /data/providers/aws/environments/prod/16-cognito
+/data/providers/aws/environments/stg/10-acm
+/data/providers/aws/environments/stg/11-images
+/data/providers/aws/environments/stg/16-cognito
 '
 
 for tfstateDir in ${tfstateDirList}; do

--- a/terraform-init.sh
+++ b/terraform-init.sh
@@ -8,6 +8,7 @@ tfstateDirList='
 /data/providers/aws/environments/prod/12-vercel
 /data/providers/aws/environments/prod/13-txt
 /data/providers/aws/environments/prod/14-iam
+/data/providers/aws/environments/prod/15-ses
 '
 
 for tfstateDir in ${tfstateDirList}; do

--- a/terraform-init.sh
+++ b/terraform-init.sh
@@ -9,6 +9,7 @@ tfstateDirList='
 /data/providers/aws/environments/prod/13-txt
 /data/providers/aws/environments/prod/14-iam
 /data/providers/aws/environments/prod/15-ses
+/data/providers/aws/environments/prod/16-cognito
 '
 
 for tfstateDir in ${tfstateDirList}; do


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-terraform/issues/16

# Doneの定義
- https://github.com/nekochans/lgtm-cat-terraform/issues/16 の完了の定義を満たしている事

# 変更点概要
CognitoUserPoolを作成し、https://github.com/nekochans/lgtm-cat-api に見立てたリソースサーバーと https://github.com/nekochans/lgtm-cat-frontend のサーバーサイド部分で利用するクライアントIDを作成。

APIの認証・認可の仕組みは https://github.com/keitakn/go-cognito-lambda#api%E3%81%AE%E8%AA%8D%E8%A8%BC%E8%AA%8D%E5%8F%AF%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6 を参照。

https://github.com/keitakn/go-cognito-lambda/blob/cf695c730413736b60417050e386696926428fa5/serverless.yml#L43 のようにAPIGatewayV2のJWTAuthorizers を利用する想定、これはServerlessFrameworkでの設定例だがTerraformを用いても同様の設定は可能。

CognitoUserPoolがSESによるメール送信設定を推奨しているので、SESの設定を作成。（本番環境のみ）

# レビュアーに重点的にチェックして欲しい点

アーキテクチャ的には微妙だけどSESの設定は1つのAWSアカウントで1つあれば良いので、ステージング用のCognitoUserPoolから本番用のSESのリソースに依存するという形になっているよ、この方針で問題ないか確認をお願いしたい:pray:

（多分RDSとかも料金節約の観点で同じように本番用にリソース作成してDBスキーマだけステージング用を作るって形を取ると思うから、まあSESも本番用だけあれば良いという気持ちも少しあった🐱）

# 補足情報
SESの設定はCognitoUserPoolの警告を消す為に行ったが、[LGTMeow](https://lgtmeow.com/) はGitHubアカウント以外での登録手段を追加する予定はないので実際にCognitoUserPoolからメールが送信される事はないと思う。