### PR TITLE
APIに必要なAPI GatewayとLambdaの構築

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@
 # IDEA Setting File
 .idea
 terraform-boilerplate.iml
+
+modules/aws/lambda/function/lambda.zip

--- a/modules/aws/api_gateway/http_api.tf
+++ b/modules/aws/api_gateway/http_api.tf
@@ -1,0 +1,38 @@
+resource "aws_apigatewayv2_api" "api" {
+  name          = var.api_gateway_name
+  protocol_type = "HTTP"
+  target        = var.lambda_arn
+}
+
+resource "aws_apigatewayv2_route" "api" {
+  api_id             = aws_apigatewayv2_api.api.id
+  route_key          = "ANY /{proxy+}"
+  target             = "integrations/${aws_apigatewayv2_integration.api.id}"
+  authorization_type = "NONE"
+}
+
+resource "aws_apigatewayv2_integration" "api" {
+  api_id = aws_apigatewayv2_api.api.id
+
+  integration_type   = "AWS_PROXY"
+  connection_type    = "INTERNET"
+  description        = "${var.api_gateway_name} serverless api"
+  integration_method = "POST"
+  integration_uri    = var.lambda_invoke_arn
+}
+
+resource "aws_apigatewayv2_domain_name" "api" {
+  domain_name = var.api_gateway_domain_name
+
+  domain_name_configuration {
+    certificate_arn = var.certificate_arn
+    endpoint_type   = "REGIONAL"
+    security_policy = "TLS_1_2"
+  }
+}
+
+resource "aws_apigatewayv2_api_mapping" "api" {
+  api_id      = aws_apigatewayv2_api.api.id
+  stage       = "$default"
+  domain_name = aws_apigatewayv2_domain_name.api.domain_name
+}

--- a/modules/aws/api_gateway/iam_policy_document.tf
+++ b/modules/aws/api_gateway/iam_policy_document.tf
@@ -1,0 +1,18 @@
+data "aws_iam_policy_document" "api_policy" {
+  statement {
+    effect = "Allow"
+    principals {
+      type = "*"
+      identifiers = [
+      "*"]
+    }
+    actions = [
+      "execute-api:Invoke"
+    ]
+    resources = [
+      "arn:aws:execute-api:ap-northeast-1:*:*/*/*"
+    ]
+  }
+}
+
+

--- a/modules/aws/api_gateway/lambda_permission.tf
+++ b/modules/aws/api_gateway/lambda_permission.tf
@@ -1,0 +1,10 @@
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+resource "aws_lambda_permission" "apigateway_lambda" {
+  action        = "lambda:InvokeFunction"
+  function_name = var.lambda_function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.api.execution_arn}/*/*/*"
+}
+

--- a/modules/aws/api_gateway/route53.tf
+++ b/modules/aws/api_gateway/route53.tf
@@ -1,0 +1,11 @@
+resource "aws_route53_record" "apigateway" {
+  zone_id = var.zone_id
+  name    = aws_apigatewayv2_domain_name.api.domain_name
+  type    = "A"
+
+  alias {
+    name                   = aws_apigatewayv2_domain_name.api.domain_name_configuration.0.target_domain_name
+    zone_id                = aws_apigatewayv2_domain_name.api.domain_name_configuration.0.hosted_zone_id
+    evaluate_target_health = false
+  }
+}

--- a/modules/aws/api_gateway/variables.tf
+++ b/modules/aws/api_gateway/variables.tf
@@ -1,0 +1,30 @@
+variable "lambda_function_name" {
+  type = string
+}
+
+variable "lambda_invoke_arn" {
+  type = string
+}
+
+variable "lambda_arn" {
+  type = string
+}
+
+variable "api_gateway_name" {
+  type = string
+}
+
+variable "auto_deploy" {
+  type = bool
+}
+
+variable "api_gateway_domain_name" {
+  type = string
+}
+variable "certificate_arn" {
+  type = string
+}
+
+variable "zone_id" {
+  type = string
+}

--- a/modules/aws/lambda/function/main.go
+++ b/modules/aws/lambda/function/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"fmt"
+)
+
+func main() {
+	fmt.Println("Hello world!")
+}

--- a/modules/aws/lambda/iam.tf
+++ b/modules/aws/lambda/iam.tf
@@ -1,0 +1,41 @@
+data "aws_iam_policy_document" "lambda" {
+  statement {
+    effect = "Allow"
+
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "lambda_api" {
+  name               = var.lambda_api_iam_role_name
+  assume_role_policy = data.aws_iam_policy_document.lambda.json
+}
+
+data "aws_iam_policy_document" "lambda_api" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents"
+    ]
+    resources = [
+      "arn:aws:logs:*:*:*"
+    ]
+  }
+}
+
+resource "aws_iam_policy" "lambda_api" {
+  name   = var.lambda_api_iam_policy_name
+  policy = data.aws_iam_policy_document.lambda_api.json
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_api" {
+  role       = aws_iam_role.lambda_api.name
+  policy_arn = aws_iam_policy.lambda_api.arn
+}

--- a/modules/aws/lambda/main.tf
+++ b/modules/aws/lambda/main.tf
@@ -1,0 +1,30 @@
+data "archive_file" "lambda_function" {
+  type        = "zip"
+  source_dir  = "${path.module}/function"
+  output_path = "${path.module}/function/lambda.zip"
+}
+
+resource "aws_lambda_function" "api" {
+  filename         = data.archive_file.lambda_function.output_path
+  source_code_hash = data.archive_file.lambda_function.output_base64sha256
+  function_name    = var.lambda_function_name
+  role             = aws_iam_role.lambda_api.arn
+  handler          = "lambda"
+  runtime          = "go1.x"
+
+  memory_size = 128
+  timeout     = 900
+
+  lifecycle {
+    ignore_changes = [
+      last_modified,
+      source_code_hash,
+      version,
+    ]
+  }
+}
+
+resource "aws_cloudwatch_log_group" "api" {
+  name              = "/aws/lambda/${var.lambda_function_name}"
+  retention_in_days = var.log_retention_in_days
+}

--- a/modules/aws/lambda/outputs.tf
+++ b/modules/aws/lambda/outputs.tf
@@ -1,0 +1,11 @@
+output "lambda_function_name" {
+  value = aws_lambda_function.api.function_name
+}
+
+output "lambda_invoke_arn" {
+  value = aws_lambda_function.api.invoke_arn
+}
+
+output "lambda_arn" {
+  value = aws_lambda_function.api.arn
+}

--- a/modules/aws/lambda/variables.tf
+++ b/modules/aws/lambda/variables.tf
@@ -1,0 +1,15 @@
+variable "lambda_function_name" {
+  type = string
+}
+
+variable "lambda_api_iam_role_name" {
+  type = string
+}
+
+variable "lambda_api_iam_policy_name" {
+  type = string
+}
+
+variable "log_retention_in_days" {
+  type = number
+}

--- a/providers/aws/environments/prod/16-cognito/.terraform.lock.hcl
+++ b/providers/aws/environments/prod/16-cognito/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "3.29.0"
   constraints = "3.29.0"
   hashes = [
+    "h1:0eN4GvXAJs8E9GseVaco7P9H6qhWKIVkGQEPFyUIBXE=",
     "h1:euXiL7Q/8CZ7eFO8ktcDVNEV51tJpicreQGazmNSGCg=",
     "zh:0e3ec82025efcfed94180858240a1be147bc3eabb24a755f8c58970173b71e54",
     "zh:22897ef5b00317ffa2495a5582c567a4ceca09e9071e0888b18c8364bab6d31b",

--- a/providers/aws/environments/prod/16-cognito/main.tf
+++ b/providers/aws/environments/prod/16-cognito/main.tf
@@ -1,4 +1,4 @@
-module "iam" {
+module "cognito" {
   source                                  = "../../../../../modules/aws/cognito"
   user_pool_name                          = local.user_pool_name
   user_pool_domain_name                   = local.user_pool_domain_name

--- a/providers/aws/environments/stg/17-api/.terraform.lock.hcl
+++ b/providers/aws/environments/stg/17-api/.terraform.lock.hcl
@@ -1,0 +1,38 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.2.0"
+  hashes = [
+    "h1:2K5LQkuWRS2YN1/YoNaHn9MAzjuTX8Gaqy6i8Mbfv8Y=",
+    "zh:06bd875932288f235c16e2237142b493c2c2b6aba0e82e8c85068332a8d2a29e",
+    "zh:0c681b481372afcaefddacc7ccdf1d3bb3a0c0d4678a526bc8b02d0c331479bc",
+    "zh:100fc5b3fc01ea463533d7bbfb01cb7113947a969a4ec12e27f5b2be49884d6c",
+    "zh:55c0d7ddddbd0a46d57c51fcfa9b91f14eed081a45101dbfc7fd9d2278aa1403",
+    "zh:73a5dd68379119167934c48afa1101b09abad2deb436cd5c446733e705869d6b",
+    "zh:841fc4ac6dc3479981330974d44ad2341deada8a5ff9e3b1b4510702dfbdbed9",
+    "zh:91be62c9b41edb137f7f835491183628d484e9d6efa82fcb75cfa538c92791c5",
+    "zh:acd5f442bd88d67eb948b18dc2ed421c6c3faee62d3a12200e442bfff0aa7d8b",
+    "zh:ad5720da5524641ad718a565694821be5f61f68f1c3c5d2cfa24426b8e774bef",
+    "zh:e63f12ea938520b3f83634fc29da28d92eed5cfbc5cc8ca08281a6a9c36cca65",
+    "zh:f6542918faa115df46474a36aabb4c3899650bea036b5f8a5e296be6f8f25767",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.29.0"
+  constraints = "3.29.0"
+  hashes = [
+    "h1:0eN4GvXAJs8E9GseVaco7P9H6qhWKIVkGQEPFyUIBXE=",
+    "zh:0e3ec82025efcfed94180858240a1be147bc3eabb24a755f8c58970173b71e54",
+    "zh:22897ef5b00317ffa2495a5582c567a4ceca09e9071e0888b18c8364bab6d31b",
+    "zh:2e98fc511787045e5ef6f0e76d92ea8de27cd168b20902f9e57d75c96dcb80d8",
+    "zh:4e86f7f25c27c139ae17e3ad2a82a154b115d83f16bf8d8fee2aba9f00c80437",
+    "zh:71ba0b2b10a5e83b276ebca1d8559354c12656310bfd2554591ac6f0f5541bd0",
+    "zh:771989dadb5921bf4586c749a537116eaafdd854e542c5890c9dac55d7b2f8ac",
+    "zh:7aa3095c12174b6f8f525ba6007312df6b95de4b4137d25414144e7731ac202c",
+    "zh:a1c6f9a6f1abee0cc9c4a3a912c0e6571e7cc439701f03172de44b4187e66769",
+    "zh:bd50937e68e9434fc482817e9acfe486b95c69494194627884091a0581a0dffd",
+    "zh:e035fd1df86f709374a8547ac141edd1bd899cc7d979b7b28da3ad62fa6ff47b",
+  ]
+}

--- a/providers/aws/environments/stg/17-api/backend.tf
+++ b/providers/aws/environments/stg/17-api/backend.tf
@@ -1,0 +1,19 @@
+terraform {
+  backend "s3" {
+    bucket  = "stg-lgtm-cat-tfstate"
+    key     = "api/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "lgtm-cat"
+  }
+}
+
+data "terraform_remote_state" "acm" {
+  backend = "s3"
+
+  config = {
+    bucket  = "lgtm-cat-tfstate"
+    key     = "acm/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "lgtm-cat"
+  }
+}

--- a/providers/aws/environments/stg/17-api/main.tf
+++ b/providers/aws/environments/stg/17-api/main.tf
@@ -1,0 +1,23 @@
+module "lambda" {
+  source = "../../../../../modules/aws/lambda"
+
+  lambda_function_name       = local.lambda_function_name
+  lambda_api_iam_policy_name = local.lambda_api_iam_policy_name
+  lambda_api_iam_role_name   = local.lambda_api_iam_role_name
+  log_retention_in_days      = local.log_retention_in_days
+}
+
+module "api_gateway" {
+  source = "../../../../../modules/aws/api_gateway"
+
+  lambda_function_name    = module.lambda.lambda_function_name
+  lambda_invoke_arn       = module.lambda.lambda_invoke_arn
+  lambda_arn              = module.lambda.lambda_arn
+  api_gateway_name        = local.api_gateway_name
+  api_gateway_domain_name = local.api_gateway_domain_name
+  auto_deploy             = local.auto_deploy
+  certificate_arn         = local.certificate_arn
+  zone_id                 = data.aws_route53_zone.api.zone_id
+
+  depends_on = [module.lambda]
+}

--- a/providers/aws/environments/stg/17-api/provider.tf
+++ b/providers/aws/environments/stg/17-api/provider.tf
@@ -1,0 +1,6 @@
+provider "aws" {
+  region  = "ap-northeast-1"
+  profile = "lgtm-cat"
+}
+
+provider "archive" {}

--- a/providers/aws/environments/stg/17-api/variables.tf
+++ b/providers/aws/environments/stg/17-api/variables.tf
@@ -8,7 +8,7 @@ locals {
 
   api_gateway_name        = "${local.env}-lgtm-cat-api"
   auto_deploy             = true
-  api_gateway_domain_name = "stg-lgtm-cat-api.${var.main_domain_name}"
+  api_gateway_domain_name = "${local.env}-api.${var.main_domain_name}"
   certificate_arn         = data.terraform_remote_state.acm.outputs.ap_northeast_1_sub_domain_acm_arn
 }
 

--- a/providers/aws/environments/stg/17-api/variables.tf
+++ b/providers/aws/environments/stg/17-api/variables.tf
@@ -1,0 +1,22 @@
+locals {
+  env = "stg"
+
+  lambda_function_name       = "${local.env}-lgtm-cat-api"
+  lambda_api_iam_policy_name = "${local.env}-lgtm-cat-api-policy"
+  lambda_api_iam_role_name   = "${local.env}-lgtm-cat-api-role"
+  log_retention_in_days      = 3
+
+  api_gateway_name        = "${local.env}-lgtm-cat-api"
+  auto_deploy             = true
+  api_gateway_domain_name = "stg-lgtm-cat-api.${var.main_domain_name}"
+  certificate_arn         = data.terraform_remote_state.acm.outputs.ap_northeast_1_sub_domain_acm_arn
+}
+
+variable "main_domain_name" {
+  type    = string
+  default = "lgtmeow.com"
+}
+
+data "aws_route53_zone" "api" {
+  name = var.main_domain_name
+}

--- a/providers/aws/environments/stg/17-api/versions.tf
+++ b/providers/aws/environments/stg/17-api/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = "0.14.7"
+
+  required_providers {
+    aws = "3.29.0"
+  }
+}


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-terraform/issues/28

# Doneの定義
https://github.com/nekochans/lgtm-cat-terraform/issues/28 の完了の定義が満たされていること

# 変更点概要
下記の記事を参考にAPI GatewayとLambdaの構築を行った。
https://future-architect.github.io/articles/20200927/

上記の記事と異なる点は下記の通り。
- API Gateway は REST API ではなく HTTP API を利用
- API Gateway にカスタムドメインを指定(https://stg-api.lgtmeow.com/hello) 

なお、STGとPROD環境は別のリソースを構築することを想定し、API Gatewayのステージの構築は行なっていない。 
また、PROD用のリソース構築はAPIの実装後、別のPRで対応する予定。

# レビュアーに重点的にチェックして欲しい点
- LambdaをSTG、PRODと別のリソースとして構築する方針で問題ないか

# 補足
API Gatewayには最終的にはcognitoを利用したauthorizerを設定することになるが、別の課題として対応する。