### PR TITLE
S3への権限をLambdaの実行ロールに追加

### DIFF
--- a/modules/aws/lambda/iam.tf
+++ b/modules/aws/lambda/iam.tf
@@ -28,8 +28,18 @@ data "aws_iam_policy_document" "lambda_api" {
       "arn:aws:logs:*:*:*"
     ]
   }
-}
 
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:*"
+    ]
+    resources = [
+      "arn:aws:s3:::${var.s3_bucket_name}",
+      "arn:aws:s3:::${var.s3_bucket_name}/*"
+    ]
+  }
+}
 resource "aws_iam_policy" "lambda_api" {
   name   = var.lambda_api_iam_policy_name
   policy = data.aws_iam_policy_document.lambda_api.json

--- a/modules/aws/lambda/variables.tf
+++ b/modules/aws/lambda/variables.tf
@@ -13,3 +13,7 @@ variable "lambda_api_iam_policy_name" {
 variable "log_retention_in_days" {
   type = number
 }
+
+variable "s3_bucket_name" {
+  type = string
+}

--- a/providers/aws/environments/stg/17-api/.terraform.lock.hcl
+++ b/providers/aws/environments/stg/17-api/.terraform.lock.hcl
@@ -4,7 +4,7 @@
 provider "registry.terraform.io/hashicorp/archive" {
   version = "2.2.0"
   hashes = [
-    "h1:2K5LQkuWRS2YN1/YoNaHn9MAzjuTX8Gaqy6i8Mbfv8Y=",
+    "h1:CIWi5G6ob7p2wWoThRQbOB8AbmFlCzp7Ka81hR3cVp0=",
     "zh:06bd875932288f235c16e2237142b493c2c2b6aba0e82e8c85068332a8d2a29e",
     "zh:0c681b481372afcaefddacc7ccdf1d3bb3a0c0d4678a526bc8b02d0c331479bc",
     "zh:100fc5b3fc01ea463533d7bbfb01cb7113947a969a4ec12e27f5b2be49884d6c",
@@ -23,7 +23,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "3.29.0"
   constraints = "3.29.0"
   hashes = [
-    "h1:0eN4GvXAJs8E9GseVaco7P9H6qhWKIVkGQEPFyUIBXE=",
+    "h1:euXiL7Q/8CZ7eFO8ktcDVNEV51tJpicreQGazmNSGCg=",
     "zh:0e3ec82025efcfed94180858240a1be147bc3eabb24a755f8c58970173b71e54",
     "zh:22897ef5b00317ffa2495a5582c567a4ceca09e9071e0888b18c8364bab6d31b",
     "zh:2e98fc511787045e5ef6f0e76d92ea8de27cd168b20902f9e57d75c96dcb80d8",

--- a/providers/aws/environments/stg/17-api/backend.tf
+++ b/providers/aws/environments/stg/17-api/backend.tf
@@ -17,3 +17,14 @@ data "terraform_remote_state" "acm" {
     profile = "lgtm-cat"
   }
 }
+
+data "terraform_remote_state" "images" {
+  backend = "s3"
+
+  config = {
+    bucket  = "stg-lgtm-cat-tfstate"
+    key     = "images/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "lgtm-cat"
+  }
+}

--- a/providers/aws/environments/stg/17-api/main.tf
+++ b/providers/aws/environments/stg/17-api/main.tf
@@ -5,6 +5,7 @@ module "lambda" {
   lambda_api_iam_policy_name = local.lambda_api_iam_policy_name
   lambda_api_iam_role_name   = local.lambda_api_iam_role_name
   log_retention_in_days      = local.log_retention_in_days
+  s3_bucket_name             = data.terraform_remote_state.images.outputs.upload_images_bucket_name
 }
 
 module "api_gateway" {


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-terraform/issues/30

# Doneの定義
https://github.com/nekochans/lgtm-cat-terraform/issues/30 の完了の定義が満たされていること

# 変更点概要
lgtm-cat-api 用のLambdaの実行ロールにS3への権限を追加。
IAMポリシーで`resources`にS3バケット名を指定することで、対象を絞っている。

LambdaからS3バケットにファイルをアップロードできることは確認済み。

また、.terraform.lock.hcl がローカルで作成したものだったのでDocker上で作成した内容に更新。