### PR TITLE
terraform-init.sh を最新の状態に更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,13 +86,13 @@ aws_secret_access_key = あなたのシークレットアクセスキー
 
 以下のファイルを配置して下さい。
 
-#### providers/aws/environments/prod/13-txt/terraform.tfvars
+#### providers/aws/environments/prod/14-txt/terraform.tfvars
 
 ```terraform
 txt_records = ["google-site-verification=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"]
 ```
 
-#### providers/aws/environments/prod/15-ses/terraform.tfvars
+#### providers/aws/environments/prod/16-ses/terraform.tfvars
 
 ```terraform
 from_email = "us-east-1のSES EmailAddressesに定義されているメールアドレスを指定"
@@ -119,11 +119,13 @@ lgtm-cat-terraform/
      └ aws/
        └ environments/
          ├ stg/
-         │ ├ 11-images/
-         │ └ 20-xxxx/
+         │ ├ 10-network/
+         │ ├ 11-acm/
+         │ └ 22-xxxx/
          └ prod/
-           ├ 11-images/
-           └ 20-xxxx/
+           ├ 10-network/
+           ├ 11-acm/
+           └ 22-xxxx/
 ```
 
 ### 環境分割

--- a/terraform-init.sh
+++ b/terraform-init.sh
@@ -1,16 +1,21 @@
 #!/bin/sh
 
 tfstateDirList='
-/data/providers/aws/environments/prod/10-acm
-/data/providers/aws/environments/prod/11-images
-/data/providers/aws/environments/prod/12-vercel
-/data/providers/aws/environments/prod/13-txt
-/data/providers/aws/environments/prod/14-iam
-/data/providers/aws/environments/prod/15-ses
-/data/providers/aws/environments/prod/16-cognito
-/data/providers/aws/environments/stg/10-acm
-/data/providers/aws/environments/stg/11-images
-/data/providers/aws/environments/stg/16-cognito
+/data/providers/aws/environments/prod/10-network
+/data/providers/aws/environments/prod/11-acm
+/data/providers/aws/environments/prod/12-images
+/data/providers/aws/environments/prod/13-vercel
+/data/providers/aws/environments/prod/14-txt
+/data/providers/aws/environments/prod/15-iam
+/data/providers/aws/environments/prod/16-ses
+/data/providers/aws/environments/prod/17-cognito
+/data/providers/aws/environments/prod/22-migration
+/data/providers/aws/environments/prod/23-rds
+/data/providers/aws/environments/stg/11-acm
+/data/providers/aws/environments/stg/12-images
+/data/providers/aws/environments/stg/17-cognito
+/data/providers/aws/environments/stg/20-api
+/data/providers/aws/environments/stg/21-lambda-securitygroup
 '
 
 for tfstateDir in ${tfstateDirList}; do


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-terraform/issues/43

# 関連URL
なし

# Doneの定義
- https://github.com/nekochans/lgtm-cat-terraform/issues/43 の完了の定義を満たしている事

# 変更点概要
`terraform-init.sh` を今のディレクトリ構成に合わせて最新に更新、またREADMEに書かれているディレクトリ名やパスが以前のままだったので今の状態に合わせて更新。

# レビュアーに重点的にチェックして欲しい点

@kobayashi-m42 動作確認済だけど、念の為、READMEの記述（環境変数ファイルのパスとか）が間違っていないか確認してもらえると:pray:

# 補足情報

@kobayashi-m42 今回のPRとは関係ないけど、 `terraform plan` でいくつか差分が出たんだけど、これって単純に `ignore_changes` しちゃって大丈夫かな？もし方針問題なければ、issue作って対応しようかなと🐱！

## `/data/providers/aws/environments/prod/12-images` 

```
Note: Objects have changed outside of Terraform

Terraform detected the following changes made outside of Terraform since the last "terraform apply":

  # module.images.aws_cloudfront_origin_access_identity.lgtm_images_bucket has been changed
  ~ resource "aws_cloudfront_origin_access_identity" "lgtm_images_bucket" {
      ~ etag                            = "EXXXXXXXXXXXX" -> "EYYYYYYYYYYYY"
        id                              = "EAAAAAAAAAAAA"
        # (5 unchanged attributes hidden)
    }

Unless you have made equivalent changes to your configuration, or ignored the relevant attributes using ignore_changes, the following plan may include actions to
undo or respond to these changes.
```

## /data/providers/aws/environments/prod/22-migration

```
Note: Objects have changed outside of Terraform

Terraform detected the following changes made outside of Terraform since the last "terraform apply":

  # module.migration.aws_ecs_cluster.migration has been changed
  ~ resource "aws_ecs_cluster" "migration" {
        id                 = "arn:aws:ecs:ap-northeast-1:0000000000:cluster/lgtm-cat-migration-cluster"
        name               = "lgtm-cat-migration-cluster"
        tags               = {}
        # (3 unchanged attributes hidden)

      - setting {
          - name  = "containerInsights" -> null
          - value = "disabled" -> null
        }
    }

Unless you have made equivalent changes to your configuration, or ignored the relevant attributes using ignore_changes, the following plan may include actions to
undo or respond to these changes.
```

## /data/providers/aws/environments/prod/23-rds

```
Note: Objects have changed outside of Terraform

Terraform detected the following changes made outside of Terraform since the last "terraform apply":

  # module.rds.aws_ecs_cluster.bastion has been changed
  ~ resource "aws_ecs_cluster" "bastion" {
        id                 = "arn:aws:ecs:ap-northeast-1:0000000000:cluster/lgtm-cat-bastion-cluster"
        name               = "lgtm-cat-bastion-cluster"
        tags               = {}
        # (3 unchanged attributes hidden)


      - setting {
          - name  = "containerInsights" -> null
          - value = "disabled" -> null
        }
        # (1 unchanged block hidden)
    }

Unless you have made equivalent changes to your configuration, or ignored the relevant attributes using ignore_changes, the following plan may include actions to
undo or respond to these changes.
```

## /data/providers/aws/environments/prod/23-rds

```
Note: Objects have changed outside of Terraform

Terraform detected the following changes made outside of Terraform since the last "terraform apply":

  # module.lambda.aws_security_group_rule.lambda_egress has been changed
  ~ resource "aws_security_group_rule" "lambda_egress" {
        id                = "sgrule-0000000000"
      + ipv6_cidr_blocks  = []
      + prefix_list_ids   = []
        # (7 unchanged attributes hidden)
    }
  # module.lambda.aws_security_group.lambda has been changed
  ~ resource "aws_security_group" "lambda" {
      ~ egress                 = [
          + {
              + cidr_blocks      = [
                  + "0.0.0.0/0",
                ]
              + description      = ""
              + from_port        = 0
              + ipv6_cidr_blocks = []
              + prefix_list_ids  = []
              + protocol         = "-1"
              + security_groups  = []
              + self             = false
              + to_port          = 0
            },
        ]
        id                     = "sg-xxxxxxxxxxxxxxxxx"
        name                   = "stg-store-lgtm-image-lambda"
        tags                   = {
            "Name" = "stg-store-lgtm-image-lambda"
        }
        # (6 unchanged attributes hidden)
    }

Unless you have made equivalent changes to your configuration, or ignored the relevant attributes using ignore_changes, the following plan may include actions to
undo or respond to these changes.
```