### PR TITLE
terraform planの差分確認&対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,21 @@ resource "aws_key_pair" "ssh_key_pair" {
 
 そうしないと全ての `.tf` ファイルに修正が適応されません。
 
+## 運用上の注意点
+
+リソース変更を行っていないにも関わらず `terraform plan` で差分が発生する事があります。
+
+Terraform以外の手段でリソースが変更された場合は差分が出るようになっている為です。
+
+```
+No changes. Your infrastructure matches the configuration.
+
+Your configuration already matches the changes detected above. If you'd like to update the Terraform state to match, create and apply a refresh-only plan:
+  terraform apply -refresh-only
+```
+
+このように `No changes. Your infrastructure matches the configuration.` が表示されている場合は `terraform apply -refresh-only` を実行して下さい。
+
 ## ECS Exec
 
 踏み台用の ECS Cluster を構築しています。


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-terraform/issues/45

# Doneの定義
- https://github.com/nekochans/lgtm-cat-terraform/issues/45 の完了の定義を満たしている事

# 変更点概要
`terraform plan` で差分がある箇所をチェックして必要な箇所で `terraform apply -refresh-only` を実行。

以下のディレクトリ配下で実行を行った。

- /data/providers/aws/environments/prod/12-images
- /data/providers/aws/environments/stg/12-images
- /data/providers/aws/environments/prod/22-migration
- /data/providers/aws/environments/prod/23-rds

`terraform apply -refresh-only` を実行しても良いケースをREADMEに追加。