### PR TITLE
ねこ画像と判定された元画像は永続的に残すように変更

### DIFF
--- a/modules/aws/images/main.tf
+++ b/modules/aws/images/main.tf
@@ -27,7 +27,7 @@ resource "aws_s3_bucket" "cat_images_bucket" {
   force_destroy = true
 
   versioning {
-    enabled = false
+    enabled = true
   }
 
   lifecycle_rule {


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-terraform/issues/48

# Doneの定義
- https://github.com/nekochans/lgtm-cat-terraform/issues/48 の完了の定義を満たしている事

# 変更点概要
今後画像を作り直す可能性もあるので、ねこ画像と判定された画像は永続的に残すようにする為、versioningを有効化。

この設定は現状LGTM画像を配信している `lgtm_images_bucket` と同じ設定。