### PR TITLE
Client Credentials Grant(RFC 6749) で発行されたアクセストークンでAPIを保護する設定を追加

### DIFF
--- a/modules/aws/api-gateway/http-api.tf
+++ b/modules/aws/api-gateway/http-api.tf
@@ -4,11 +4,24 @@ resource "aws_apigatewayv2_api" "api" {
   target        = var.lambda_arn
 }
 
+resource "aws_apigatewayv2_authorizer" "bff_authorizer" {
+  api_id           = aws_apigatewayv2_api.api.id
+  authorizer_type  = "JWT"
+  identity_sources = ["$request.header.Authorization"]
+  name             = var.bff_authorizer_name
+
+  jwt_configuration {
+    audience = [var.bff_authorizer_audience]
+    issuer   = var.bff_authorizer_issuer_url
+  }
+}
+
 resource "aws_apigatewayv2_route" "api" {
   api_id             = aws_apigatewayv2_api.api.id
   route_key          = "ANY /{proxy+}"
   target             = "integrations/${aws_apigatewayv2_integration.api.id}"
-  authorization_type = "NONE"
+  authorization_type = "JWT"
+  authorizer_id      = aws_apigatewayv2_authorizer.bff_authorizer.id
 }
 
 resource "aws_apigatewayv2_integration" "api" {

--- a/modules/aws/api-gateway/http-api.tf
+++ b/modules/aws/api-gateway/http-api.tf
@@ -4,15 +4,15 @@ resource "aws_apigatewayv2_api" "api" {
   target        = var.lambda_arn
 }
 
-resource "aws_apigatewayv2_authorizer" "bff_authorizer" {
+resource "aws_apigatewayv2_authorizer" "jwt_authorizer" {
   api_id           = aws_apigatewayv2_api.api.id
   authorizer_type  = "JWT"
   identity_sources = ["$request.header.Authorization"]
-  name             = var.bff_authorizer_name
+  name             = var.jwt_authorizer_name
 
   jwt_configuration {
-    audience = [var.bff_authorizer_audience]
-    issuer   = var.bff_authorizer_issuer_url
+    audience = [var.lgtm_cat_bff_client_id]
+    issuer   = var.jwt_authorizer_issuer_url
   }
 }
 
@@ -21,7 +21,7 @@ resource "aws_apigatewayv2_route" "api" {
   route_key          = "ANY /{proxy+}"
   target             = "integrations/${aws_apigatewayv2_integration.api.id}"
   authorization_type = "JWT"
-  authorizer_id      = aws_apigatewayv2_authorizer.bff_authorizer.id
+  authorizer_id      = aws_apigatewayv2_authorizer.jwt_authorizer.id
 }
 
 resource "aws_apigatewayv2_integration" "api" {

--- a/modules/aws/api-gateway/variables.tf
+++ b/modules/aws/api-gateway/variables.tf
@@ -28,3 +28,15 @@ variable "certificate_arn" {
 variable "zone_id" {
   type = string
 }
+
+variable "bff_authorizer_name" {
+  type = string
+}
+
+variable "bff_authorizer_issuer_url" {
+  type = string
+}
+
+variable "bff_authorizer_audience" {
+  type = string
+}

--- a/modules/aws/api-gateway/variables.tf
+++ b/modules/aws/api-gateway/variables.tf
@@ -29,14 +29,14 @@ variable "zone_id" {
   type = string
 }
 
-variable "bff_authorizer_name" {
+variable "jwt_authorizer_name" {
   type = string
 }
 
-variable "bff_authorizer_issuer_url" {
+variable "jwt_authorizer_issuer_url" {
   type = string
 }
 
-variable "bff_authorizer_audience" {
+variable "lgtm_cat_bff_client_id" {
   type = string
 }

--- a/modules/aws/cognito/outputs.tf
+++ b/modules/aws/cognito/outputs.tf
@@ -1,0 +1,7 @@
+output "idp_endpoint" {
+  value = aws_cognito_user_pool.user_pool.endpoint
+}
+
+output "lgtm_cat_bff_client_id" {
+  value = aws_cognito_user_pool_client.lgtm_cat_bff_client.id
+}

--- a/providers/aws/environments/prod/17-cognito/outputs.tf
+++ b/providers/aws/environments/prod/17-cognito/outputs.tf
@@ -1,0 +1,9 @@
+output "idp_endpoint" {
+  value     = module.cognito.idp_endpoint
+  sensitive = true
+}
+
+output "lgtm_cat_bff_client_id" {
+  value     = module.cognito.lgtm_cat_bff_client_id
+  sensitive = true
+}

--- a/providers/aws/environments/stg/17-cognito/outputs.tf
+++ b/providers/aws/environments/stg/17-cognito/outputs.tf
@@ -1,0 +1,9 @@
+output "idp_endpoint" {
+  value     = module.cognito.idp_endpoint
+  sensitive = true
+}
+
+output "lgtm_cat_bff_client_id" {
+  value     = module.cognito.lgtm_cat_bff_client_id
+  sensitive = true
+}

--- a/providers/aws/environments/stg/20-api/backend.tf
+++ b/providers/aws/environments/stg/20-api/backend.tf
@@ -28,3 +28,14 @@ data "terraform_remote_state" "images" {
     profile = "lgtm-cat"
   }
 }
+
+data "terraform_remote_state" "cognito" {
+  backend = "s3"
+
+  config = {
+    bucket  = "stg-lgtm-cat-tfstate"
+    key     = "cognito/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "lgtm-cat"
+  }
+}

--- a/providers/aws/environments/stg/20-api/main.tf
+++ b/providers/aws/environments/stg/20-api/main.tf
@@ -12,14 +12,17 @@ module "lambda" {
 module "api_gateway" {
   source = "../../../../../modules/aws/api-gateway"
 
-  lambda_function_name    = module.lambda.lambda_function_name
-  lambda_invoke_arn       = module.lambda.lambda_invoke_arn
-  lambda_arn              = module.lambda.lambda_arn
-  api_gateway_name        = local.api_gateway_name
-  api_gateway_domain_name = local.api_gateway_domain_name
-  auto_deploy             = local.auto_deploy
-  certificate_arn         = local.certificate_arn
-  zone_id                 = data.aws_route53_zone.api.zone_id
+  lambda_function_name      = module.lambda.lambda_function_name
+  lambda_invoke_arn         = module.lambda.lambda_invoke_arn
+  lambda_arn                = module.lambda.lambda_arn
+  api_gateway_name          = local.api_gateway_name
+  api_gateway_domain_name   = local.api_gateway_domain_name
+  auto_deploy               = local.auto_deploy
+  certificate_arn           = local.certificate_arn
+  zone_id                   = data.aws_route53_zone.api.zone_id
+  bff_authorizer_name       = local.bff_authorizer_name
+  bff_authorizer_issuer_url = local.bff_authorizer_issuer_url
+  bff_authorizer_audience   = local.bff_authorizer_audience
 
   depends_on = [module.lambda]
 }

--- a/providers/aws/environments/stg/20-api/main.tf
+++ b/providers/aws/environments/stg/20-api/main.tf
@@ -20,9 +20,9 @@ module "api_gateway" {
   auto_deploy               = local.auto_deploy
   certificate_arn           = local.certificate_arn
   zone_id                   = data.aws_route53_zone.api.zone_id
-  bff_authorizer_name       = local.bff_authorizer_name
-  bff_authorizer_issuer_url = local.bff_authorizer_issuer_url
-  bff_authorizer_audience   = local.bff_authorizer_audience
+  jwt_authorizer_name       = local.jwt_authorizer_name
+  jwt_authorizer_issuer_url = local.jwt_authorizer_issuer_url
+  lgtm_cat_bff_client_id    = local.lgtm_cat_bff_client_id
 
   depends_on = [module.lambda]
 }

--- a/providers/aws/environments/stg/20-api/variables.tf
+++ b/providers/aws/environments/stg/20-api/variables.tf
@@ -6,10 +6,13 @@ locals {
   lambda_api_iam_role_name   = "${local.env}-lgtm-cat-api-role"
   log_retention_in_days      = 3
 
-  api_gateway_name        = "${local.env}-lgtm-cat-api"
-  auto_deploy             = true
-  api_gateway_domain_name = "${local.env}-api.${var.main_domain_name}"
-  certificate_arn         = data.terraform_remote_state.acm.outputs.ap_northeast_1_sub_domain_acm_arn
+  api_gateway_name          = "${local.env}-lgtm-cat-api"
+  auto_deploy               = true
+  api_gateway_domain_name   = "${local.env}-api.${var.main_domain_name}"
+  certificate_arn           = data.terraform_remote_state.acm.outputs.ap_northeast_1_sub_domain_acm_arn
+  bff_authorizer_name       = "${local.env}-bff-authorizer"
+  bff_authorizer_issuer_url = "https://${data.terraform_remote_state.cognito.outputs.idp_endpoint}"
+  bff_authorizer_audience   = data.terraform_remote_state.cognito.outputs.lgtm_cat_bff_client_id
 }
 
 variable "main_domain_name" {

--- a/providers/aws/environments/stg/20-api/variables.tf
+++ b/providers/aws/environments/stg/20-api/variables.tf
@@ -10,9 +10,9 @@ locals {
   auto_deploy               = true
   api_gateway_domain_name   = "${local.env}-api.${var.main_domain_name}"
   certificate_arn           = data.terraform_remote_state.acm.outputs.ap_northeast_1_sub_domain_acm_arn
-  bff_authorizer_name       = "${local.env}-bff-authorizer"
-  bff_authorizer_issuer_url = "https://${data.terraform_remote_state.cognito.outputs.idp_endpoint}"
-  bff_authorizer_audience   = data.terraform_remote_state.cognito.outputs.lgtm_cat_bff_client_id
+  jwt_authorizer_name       = "${local.env}-jwt-authorizer"
+  jwt_authorizer_issuer_url = "https://${data.terraform_remote_state.cognito.outputs.idp_endpoint}"
+  lgtm_cat_bff_client_id    = data.terraform_remote_state.cognito.outputs.lgtm_cat_bff_client_id
 }
 
 variable "main_domain_name" {


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-terraform/issues/15

# 関連URL
- ステージング環境のAPIのURL

# Doneの定義
- ステージング環境のAPIがClient Credentials Grant(RFC 6749) で発行されたアクセストークンで保護された状態になっている事

# 変更点概要

APIを配信しているAPIGatewayV2にJWT Authorizerの設定を追加。

lgtmeow-bffのクライアントのみがアクセス出来る状態にしたかったので、audienceにはlgtmeow-bffのクライアントIDを指定してある。

## APIの呼び出し方

```
// 1. クライアントIDとクライアントシークレットを `:` で繋いでbase64した値を生成
echo -n "lgtmeow-bffのクライアントIDを指定:lgtmeow-bffのクライアントSecretを指定" | base64

// 2. クライアントクレデンシャルでアクセストークンを発行する
curl -v \
-X POST \
-H "Content-Type: application/x-www-form-urlencoded" \
-H "Authorization: Basic 1で生成した値" \
--data "grant_type=client_credentials" \
--data "scope=api.lgtmeow/all" \
https://ステージングドメイン名.auth.ap-northeast-1.amazoncognito.com/oauth2/token | jq

// 3. アクセストークン付きでAPIをコール（これは画像アップロードAPIをコールする例）
echo '{"image" : "'"$( base64 ./S__41426949.jpg)"'", "imageExtension": ".jpg"}' | \
curl -v \
-X POST \
-H "Authorization: Bearer 2で取得したアクセストークンを指定する" \
-H "Content-Type: application/json" -d @- https://ステージング用APIドメイン/lgtm-images | jq
```

トークンの指定がない、もしくは無効なトークンを指定した場合は以下のレスポンスが返ってくるようになる。

```
< HTTP/2 401
< date: Wed, 17 Nov 2021 14:55:10 GMT
< content-type: application/json
< content-length: 26
< www-authenticate: Bearer
< apigw-requestid: I9CoQjtpNjMEJbA=
<
{ [26 bytes data]
100  392k  100    26  100  392k    238  3600k --:--:-- --:--:-- --:--:-- 3600k
* Connection #0 to host stg-api.lgtmeow.com left intact
* Closing connection 0
{
  "message": "Unauthorized"
}
```

以下にクライアントID等をマスクしていないコピペするだけでAPIをコール出来るコマンドを投稿済。

https://nekochans.slack.com/archives/C01NSTL64Q0/p1637161587002900

# レビュアーに重点的にチェックして欲しい点
インラインコメントに書いてる内容を確認してもらえると:pray:

# 補足情報
開発中の https://lgtm-cat-frontend-git-release-upload-cat-images-nekochans.vercel.app/upload からもアクセストークン付きでAPIをコール出来る事を確認済。