### PR TITLE
STG環境用に RDS Proxy の認証を追加

### DIFF
--- a/modules/aws/rds/proxy.tf
+++ b/modules/aws/rds/proxy.tf
@@ -14,6 +14,12 @@ resource "aws_db_proxy" "rds_proxy" {
     secret_arn  = aws_secretsmanager_secret.rds_connection.arn
   }
 
+  auth {
+    auth_scheme = "SECRETS"
+    iam_auth    = "DISABLED"
+    secret_arn  = aws_secretsmanager_secret.rds_connection_stg.arn
+  }
+
   depends_on = [aws_rds_cluster.rds_cluster, aws_secretsmanager_secret_version.rds_connection]
 }
 

--- a/modules/aws/rds/secretmanager.tf
+++ b/modules/aws/rds/secretmanager.tf
@@ -1,5 +1,5 @@
 resource "aws_secretsmanager_secret" "rds_connection" {
-  name = "${var.rds_name}/rds-connection"
+  name = "/prod/${var.rds_name}/rds-connection"
 }
 
 resource "aws_secretsmanager_secret_version" "rds_connection" {

--- a/modules/aws/rds/secretmanager.tf
+++ b/modules/aws/rds/secretmanager.tf
@@ -14,3 +14,20 @@ resource "aws_secretsmanager_secret_version" "rds_connection" {
     dbClusterIdentifier : aws_rds_cluster.rds_cluster.id
   })
 }
+
+resource "aws_secretsmanager_secret" "rds_connection_stg" {
+  name = "/stg/${var.rds_name}/rds-connection"
+}
+
+resource "aws_secretsmanager_secret_version" "rds_connection_stg" {
+  secret_id = aws_secretsmanager_secret.rds_connection_stg.id
+
+  secret_string = jsonencode({
+    username : var.stg_app_username
+    password : var.stg_app_password
+    engine : var.proxy_engine
+    host : aws_rds_cluster.rds_cluster.endpoint
+    port : aws_rds_cluster.rds_cluster.port
+    dbClusterIdentifier : aws_rds_cluster.rds_cluster.id
+  })
+}

--- a/modules/aws/rds/variables.tf
+++ b/modules/aws/rds/variables.tf
@@ -50,6 +50,14 @@ variable "app_password" {
   type = string
 }
 
+variable "stg_app_username" {
+  type = string
+}
+
+variable "stg_app_password" {
+  type = string
+}
+
 variable "proxy_engine" {
   type = string
 }

--- a/providers/aws/environments/prod/22-migration/variables.tf
+++ b/providers/aws/environments/prod/22-migration/variables.tf
@@ -7,7 +7,7 @@ locals {
 }
 
 data "aws_secretsmanager_secret" "secret" {
-  name = "/prod/lgtm_cat"
+  name = "/prod/lgtm-cat"
 }
 
 data "aws_secretsmanager_secret_version" "secret" {

--- a/providers/aws/environments/prod/23-rds/main.tf
+++ b/providers/aws/environments/prod/23-rds/main.tf
@@ -19,4 +19,8 @@ module "rds" {
   migration_ecs_securitygroup_id = data.terraform_remote_state.migration.outputs.migration_ecs_securitygroup_id
   rds_domain_name                = local.rds_domain_name
   rds_proxy_domain_name          = local.rds_proxy_domain_name
+
+  // STG用
+  stg_app_password = local.stg_app_password
+  stg_app_username = local.stg_app_username
 }

--- a/providers/aws/environments/prod/23-rds/variables.tf
+++ b/providers/aws/environments/prod/23-rds/variables.tf
@@ -14,6 +14,10 @@ locals {
   app_username                = jsondecode(data.aws_secretsmanager_secret_version.secret.secret_string)["db_app_user"]
   rds_domain_name             = "lgtm-cat-rds"
   rds_proxy_domain_name       = "lgtm-cat-rds-proxy"
+
+  // stg
+  stg_app_password = jsondecode(data.aws_secretsmanager_secret_version.secret_stg.secret_string)["db_app_password"]
+  stg_app_username = jsondecode(data.aws_secretsmanager_secret_version.secret_stg.secret_string)["db_app_user"]
 }
 
 data "aws_secretsmanager_secret" "secret" {
@@ -22,4 +26,12 @@ data "aws_secretsmanager_secret" "secret" {
 
 data "aws_secretsmanager_secret_version" "secret" {
   secret_id = data.aws_secretsmanager_secret.secret.id
+}
+
+data "aws_secretsmanager_secret" "secret_stg" {
+  name = "/stg/lgtm_cat"
+}
+
+data "aws_secretsmanager_secret_version" "secret_stg" {
+  secret_id = data.aws_secretsmanager_secret.secret_stg.id
 }

--- a/providers/aws/environments/prod/23-rds/variables.tf
+++ b/providers/aws/environments/prod/23-rds/variables.tf
@@ -21,7 +21,7 @@ locals {
 }
 
 data "aws_secretsmanager_secret" "secret" {
-  name = "/prod/lgtm_cat"
+  name = "/prod/lgtm-cat"
 }
 
 data "aws_secretsmanager_secret_version" "secret" {
@@ -29,7 +29,7 @@ data "aws_secretsmanager_secret_version" "secret" {
 }
 
 data "aws_secretsmanager_secret" "secret_stg" {
-  name = "/stg/lgtm_cat"
+  name = "/stg/lgtm-cat"
 }
 
 data "aws_secretsmanager_secret_version" "secret_stg" {


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-terraform/issues/42

# Doneの定義
- STG環境用に RDS Proxy の認証が追加されていること

# 変更点概要
STG環境用に RDS Proxy の認証を追加した。これによりSTG環境用のユーザで、RDSに接続できるようになる。

SecretManager の名前を命名規則に合わせてスネークケースからケバブケースに変更したので、data リソースで指定している name を修正。
SecretManager はAWSコンソールから手動で設定したもののため、今回もAWSコンソールから変更している。

## 補足
その他、STG環境の migration に必要となるリソースの作成は、別のPRで対応する。