### PR TITLE
ステージング環境と本番環境、両方でMigrationが実行できる環境を構築

### DIFF
--- a/modules/aws/ecs-migration/ssm.tf
+++ b/modules/aws/ecs-migration/ssm.tf
@@ -1,26 +1,26 @@
 resource "aws_ssm_parameter" "db_hostname" {
-  name      = "/lgtm-cat/migration/DB_HOSTNAME"
+  name      = "/${var.env}/lgtm-cat/migration/DB_HOSTNAME"
   type      = "SecureString"
   value     = var.db_hostname
   overwrite = true
 }
 
 resource "aws_ssm_parameter" "db_username" {
-  name      = "/lgtm-cat/migration/DB_USERNAME"
+  name      = "/${var.env}/lgtm-cat/migration/DB_USERNAME"
   type      = "SecureString"
   value     = var.db_username
   overwrite = true
 }
 
 resource "aws_ssm_parameter" "db_name" {
-  name      = "/lgtm-cat/migration/DB_NAME"
+  name      = "/${var.env}/lgtm-cat/migration/DB_NAME"
   type      = "SecureString"
   value     = var.db_name
   overwrite = true
 }
 
 resource "aws_ssm_parameter" "db_password" {
-  name      = "/lgtm-cat/migration/DB_PASSWORD"
+  name      = "/${var.env}/lgtm-cat/migration/DB_PASSWORD"
   type      = "SecureString"
   value     = var.db_password
   overwrite = true

--- a/modules/aws/ecs-migration/variables.tf
+++ b/modules/aws/ecs-migration/variables.tf
@@ -1,3 +1,7 @@
+variable "env" {
+  type = string
+}
+
 variable "vpc_id" {
   type = string
 }

--- a/modules/aws/rds/main.tf
+++ b/modules/aws/rds/main.tf
@@ -158,3 +158,12 @@ resource "aws_security_group_rule" "rds_from_migration" {
   protocol                 = "tcp"
   source_security_group_id = var.migration_ecs_securitygroup_id
 }
+
+resource "aws_security_group_rule" "rds_from_migration_stg" {
+  security_group_id        = aws_security_group.rds_cluster.id
+  type                     = "ingress"
+  from_port                = "3306"
+  to_port                  = "3306"
+  protocol                 = "tcp"
+  source_security_group_id = var.stg_migration_ecs_securitygroup_id
+}

--- a/modules/aws/rds/route53.tf
+++ b/modules/aws/rds/route53.tf
@@ -1,4 +1,4 @@
-resource "aws_route53_zone" "rds" {
+resource "aws_route53_zone" "rds_stg" {
   name = "stg"
 
   vpc {
@@ -8,8 +8,8 @@ resource "aws_route53_zone" "rds" {
   comment = "stg RDS Local Domain"
 }
 
-resource "aws_route53_record" "rds" {
-  zone_id = aws_route53_zone.rds.zone_id
+resource "aws_route53_record" "rds_stg" {
+  zone_id = aws_route53_zone.rds_stg.zone_id
   name    = var.rds_domain_name
   type    = "CNAME"
 
@@ -17,8 +17,8 @@ resource "aws_route53_record" "rds" {
   records = [aws_rds_cluster.rds_cluster.endpoint]
 }
 
-resource "aws_route53_record" "rds_proxy" {
-  zone_id = aws_route53_zone.rds.zone_id
+resource "aws_route53_record" "rds_proxy_stg" {
+  zone_id = aws_route53_zone.rds_stg.zone_id
   name    = var.rds_proxy_domain_name
   type    = "CNAME"
 

--- a/modules/aws/rds/route53.tf
+++ b/modules/aws/rds/route53.tf
@@ -25,3 +25,31 @@ resource "aws_route53_record" "rds_proxy_stg" {
   ttl     = 300
   records = [aws_db_proxy.rds_proxy.endpoint]
 }
+
+resource "aws_route53_zone" "rds" {
+  name = "prod"
+
+  vpc {
+    vpc_id = var.vpc_id
+  }
+
+  comment = "prod RDS Local Domain"
+}
+
+resource "aws_route53_record" "rds" {
+  zone_id = aws_route53_zone.rds.zone_id
+  name    = var.rds_domain_name
+  type    = "CNAME"
+
+  ttl     = 300
+  records = [aws_rds_cluster.rds_cluster.endpoint]
+}
+
+resource "aws_route53_record" "rds_proxy" {
+  zone_id = aws_route53_zone.rds.zone_id
+  name    = var.rds_proxy_domain_name
+  type    = "CNAME"
+
+  ttl     = 300
+  records = [aws_db_proxy.rds_proxy.endpoint]
+}

--- a/modules/aws/rds/variables.tf
+++ b/modules/aws/rds/variables.tf
@@ -70,6 +70,10 @@ variable "migration_ecs_securitygroup_id" {
   type = string
 }
 
+variable "stg_migration_ecs_securitygroup_id" {
+  type = string
+}
+
 variable "rds_domain_name" {
   type = string
 }

--- a/providers/aws/environments/prod/22-migration/main.tf
+++ b/providers/aws/environments/prod/22-migration/main.tf
@@ -1,6 +1,7 @@
 module "migration" {
   source = "../../../../../modules/aws/ecs-migration"
 
+  env            = local.env
   vpc_id         = data.terraform_remote_state.network.outputs.vpc_id
   migration_name = local.migration_name
   db_hostname    = local.db_hostname

--- a/providers/aws/environments/prod/22-migration/variables.tf
+++ b/providers/aws/environments/prod/22-migration/variables.tf
@@ -1,9 +1,10 @@
 locals {
-  migration_name = "lgtm-cat-migration"
+  env            = "prod"
+  migration_name = "${local.env}-lgtm-cat-migration"
   db_password    = jsondecode(data.aws_secretsmanager_secret_version.secret.secret_string)["db_app_password"]
   db_username    = jsondecode(data.aws_secretsmanager_secret_version.secret.secret_string)["db_app_user"]
   db_name        = "lgtm_cat"
-  db_hostname    = "lgtm-cat-rds.stg"
+  db_hostname    = "lgtm-cat-rds.${local.env}"
 }
 
 data "aws_secretsmanager_secret" "secret" {

--- a/providers/aws/environments/prod/22-migration/variables.tf
+++ b/providers/aws/environments/prod/22-migration/variables.tf
@@ -3,7 +3,7 @@ locals {
   migration_name = "${local.env}-lgtm-cat-migration"
   db_password    = jsondecode(data.aws_secretsmanager_secret_version.secret.secret_string)["db_app_password"]
   db_username    = jsondecode(data.aws_secretsmanager_secret_version.secret.secret_string)["db_app_user"]
-  db_name        = "lgtm_cat"
+  db_name        = jsondecode(data.aws_secretsmanager_secret_version.secret.secret_string)["db_name"]
   db_hostname    = "lgtm-cat-rds.${local.env}"
 }
 

--- a/providers/aws/environments/prod/23-rds/backend.tf
+++ b/providers/aws/environments/prod/23-rds/backend.tf
@@ -39,3 +39,14 @@ data "terraform_remote_state" "migration" {
     profile = "lgtm-cat"
   }
 }
+
+data "terraform_remote_state" "stg_migration" {
+  backend = "s3"
+
+  config = {
+    bucket  = "stg-lgtm-cat-tfstate"
+    key     = "migration/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "lgtm-cat"
+  }
+}

--- a/providers/aws/environments/prod/23-rds/main.tf
+++ b/providers/aws/environments/prod/23-rds/main.tf
@@ -15,12 +15,13 @@ module "rds" {
   proxy_engine                   = local.proxy_engine
   app_password                   = local.app_password
   app_username                   = local.app_username
-  stg_lambda_securitygroup_id    = data.terraform_remote_state.stg_lambda_securitygroup.outputs.lambda_security_group_id
   migration_ecs_securitygroup_id = data.terraform_remote_state.migration.outputs.migration_ecs_securitygroup_id
   rds_domain_name                = local.rds_domain_name
   rds_proxy_domain_name          = local.rds_proxy_domain_name
 
   // STG用
-  stg_app_password = local.stg_app_password
-  stg_app_username = local.stg_app_username
+  stg_lambda_securitygroup_id        = data.terraform_remote_state.stg_lambda_securitygroup.outputs.lambda_security_group_id
+  stg_app_password                   = local.stg_app_password
+  stg_app_username                   = local.stg_app_username
+  stg_migration_ecs_securitygroup_id = data.terraform_remote_state.stg_migration.outputs.migration_ecs_securitygroup_id
 }

--- a/providers/aws/environments/stg/22-migration/.terraform.lock.hcl
+++ b/providers/aws/environments/stg/22-migration/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.51.0"
+  constraints = "3.51.0"
+  hashes = [
+    "h1:SG9CoqWGJgsJz27G88kBxMjQ/Pl8QGVpcXOU/tDEO84=",
+    "zh:35a28a35a106c5a4b00294f747f85aaf8feab07ece64f393e109318ca375428a",
+    "zh:9185a2e3a145abbb791b0cf98e8cdc6134d683e84f6eacae2157b8f0bdb3dbfa",
+    "zh:92897adf8e510911d6e161b34de5e05375356918137a46718f80edf86744c9e1",
+    "zh:9c2a84222a02ab661f9b7912243245c57a249d53387773b37f80a8e9e59f8866",
+    "zh:a05fbdd49ad6112d5f7bc102b5a8486d9724ab6d831b52eca69400f161e6b745",
+    "zh:ba5472f506bb6a3fb3214c7dfbaab01892f84c1f2c591619924e704a70c01a3e",
+    "zh:bd12d009f21b52f4e24b1d395922273350b97868110fe2eaf6ab3bee21c424d6",
+    "zh:be9c7b38c303d997c83649392db3588d637d80985b4c610f2bbc3f11b3a8bce8",
+    "zh:d6f7fb8378d0cd9cbbdcfdb9f80e99e5fcede08af4afca3b97916747c130278b",
+    "zh:e32963e4e3d22868ccf94f89e30649a24025b68c78b6c5e91e3aa3bb9b9c4aea",
+    "zh:eba96e9ffa19941c139326d3c942449a5d0e937ccbfcbe10b55a3c20105d6320",
+  ]
+}

--- a/providers/aws/environments/stg/22-migration/backend.tf
+++ b/providers/aws/environments/stg/22-migration/backend.tf
@@ -1,0 +1,19 @@
+terraform {
+  backend "s3" {
+    bucket  = "stg-lgtm-cat-tfstate"
+    key     = "migration/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "lgtm-cat"
+  }
+}
+
+data "terraform_remote_state" "network" {
+  backend = "s3"
+
+  config = {
+    bucket  = "lgtm-cat-tfstate"
+    key     = "network/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "lgtm-cat"
+  }
+}

--- a/providers/aws/environments/stg/22-migration/main.tf
+++ b/providers/aws/environments/stg/22-migration/main.tf
@@ -1,0 +1,12 @@
+module "migration" {
+  source = "../../../../../modules/aws/ecs-migration"
+
+  env            = local.env
+  vpc_id         = data.terraform_remote_state.network.outputs.vpc_id
+  migration_name = local.migration_name
+  db_hostname    = local.db_hostname
+  db_name        = local.db_name
+  db_password    = local.db_password
+  db_username    = local.db_username
+}
+

--- a/providers/aws/environments/stg/22-migration/outputs.tf
+++ b/providers/aws/environments/stg/22-migration/outputs.tf
@@ -1,0 +1,3 @@
+output "migration_ecs_securitygroup_id" {
+  value = module.migration.migration_ecs_security_group_id
+}

--- a/providers/aws/environments/stg/22-migration/provider.tf
+++ b/providers/aws/environments/stg/22-migration/provider.tf
@@ -1,0 +1,4 @@
+provider "aws" {
+  region  = "ap-northeast-1"
+  profile = "lgtm-cat"
+}

--- a/providers/aws/environments/stg/22-migration/variables.tf
+++ b/providers/aws/environments/stg/22-migration/variables.tf
@@ -1,0 +1,16 @@
+locals {
+  env            = "stg"
+  migration_name = "${local.env}-lgtm-cat-migration"
+  db_password    = jsondecode(data.aws_secretsmanager_secret_version.secret.secret_string)["db_app_password"]
+  db_username    = jsondecode(data.aws_secretsmanager_secret_version.secret.secret_string)["db_app_user"]
+  db_name        = jsondecode(data.aws_secretsmanager_secret_version.secret.secret_string)["db_name"]
+  db_hostname    = "lgtm-cat-rds.${local.env}"
+}
+
+data "aws_secretsmanager_secret" "secret" {
+  name = "/stg/lgtm-cat"
+}
+
+data "aws_secretsmanager_secret_version" "secret" {
+  secret_id = data.aws_secretsmanager_secret.secret.id
+}

--- a/providers/aws/environments/stg/22-migration/versions.tf
+++ b/providers/aws/environments/stg/22-migration/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = "1.0.3"
+
+  required_providers {
+    aws = "3.51.0"
+  }
+}

--- a/terraform-init.sh
+++ b/terraform-init.sh
@@ -16,6 +16,7 @@ tfstateDirList='
 /data/providers/aws/environments/stg/17-cognito
 /data/providers/aws/environments/stg/20-api
 /data/providers/aws/environments/stg/21-lambda-securitygroup
+/data/providers/aws/environments/stg/22-migration
 '
 
 for tfstateDir in ${tfstateDirList}; do


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-terraform/issues/42

# 関連URL
https://github.com/nekochans/lgtm-cat-terraform/pull/53
https://github.com/nekochans/lgtm-cat-migration/pull/6

# Doneの定義
ステージング環境と本番環境、両方でMigrationが実行出来ること

# 変更点概要
ステージング環境と本番環境、両方でMigrationが実行できる環境を構築するために下記の変更を行った。

- ece-migration module の修正
   - migration 用 ECS に設定する SSMパラメータストアを環境ごとに作成するように変更 (対象のDB、ユーザーが異なるため)
- データベース名を variables.tf に記載していたが、SecretManager から取得する形に変更
- rds module の修正
    -  PROD環境用に RDS に接続するための Route53 CNAME レコードを追加 (今までは STG 用のみ構築していた)
    - STG環境用の ECS から RDS に接続できるように SecurityGroup の ingress ルールを追加
- STG 環境に migration 実行環境のリソースを追加

# 補足情報
migration の実行の設定は、 https://github.com/nekochans/lgtm-cat-migration/pull/6 で対応している。
STG、PROD 環境にそれぞれ migration を実行できることを確認済み。
