### PR TITLE
RDSをAmazon Aurora MySQL 3にアップグレードする

### DIFF
--- a/modules/aws/rds/main.tf
+++ b/modules/aws/rds/main.tf
@@ -89,18 +89,12 @@ resource "aws_rds_cluster_parameter_group" "rds_cluster_parameter_group" {
 
   parameter {
     name  = "collation_connection"
-    value = "utf8mb4_bin"
+    value = "utf8mb4_0900_bin"
   }
 
   parameter {
     name  = "collation_server"
-    value = "utf8mb4_bin"
-  }
-
-  parameter {
-    name         = "character-set-client-handshake"
-    value        = "1"
-    apply_method = "pending-reboot"
+    value = "utf8mb4_0900_bin"
   }
 
   parameter {

--- a/providers/aws/environments/prod/23-rds/variables.tf
+++ b/providers/aws/environments/prod/23-rds/variables.tf
@@ -1,12 +1,12 @@
 locals {
   rds_name                    = "lgtm-cat"
   engine                      = "aurora-mysql"
-  engine_version              = "5.7.mysql_aurora.2.10.0"
+  engine_version              = "8.0.mysql_aurora.3.01.0"
   master_password             = jsondecode(data.aws_secretsmanager_secret_version.secret.secret_string)["db_master_password"]
   master_username             = jsondecode(data.aws_secretsmanager_secret_version.secret.secret_string)["db_master_user"]
-  instance_class              = "db.t3.small"
+  instance_class              = "db.t4g.medium"
   instance_count              = 1
-  parameter_group_family      = "aurora-mysql5.7"
+  parameter_group_family      = "aurora-mysql8.0"
   cluster_availability_zones  = ["ap-northeast-1a", "ap-northeast-1c"]
   instance_availability_zones = ["ap-northeast-1a"]
   proxy_engine                = "mysql"


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-terraform/issues/51

# Doneの定義
https://github.com/nekochans/lgtm-cat-terraform/issues/51 の完了の定義が満たされていること

# 変更点概要
Aurora MySQL のバージョンを `8.0.mysql_aurora.3.01.0` にアップグレード。
クラスターパラメータグループの `character-set-client-handshake` を下記の理由により削除した。
- skip-character-set-client-handshake を設定するはずが間違えて設定されていた
- 現時点では、UTF-8以外の文字コードを使う予定がない

# 補足情報
既存のクラスターをアップグレードすることができなかったので、一度 RDS を削除して再作成することでアップグレードを行なった。

> To upgrade an Aurora MySQL version 2 cluster to version 3, create a snapshot of the version 2 cluster and restore the snapshot to create a new version 3 cluster. Follow the procedure in Restoring from a DB cluster snapshot. Currently, in-place upgrade isn’t available from Aurora MySQL version 2 to Aurora MySQL version 3.

[Aurora MySQL version 3 compatible with MySQL 8.0 - Amazon Aurora](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.MySQL80.html#AuroraMySQL.mysql80-upgrade-example-v2-v3)