### PR TITLE
ランダムでLGTM画像を返すAPIに必要なLambdaの変更を行う

### DIFF
--- a/modules/aws/lambda/iam.tf
+++ b/modules/aws/lambda/iam.tf
@@ -20,18 +20,6 @@ data "aws_iam_policy_document" "lambda_api" {
   statement {
     effect = "Allow"
     actions = [
-      "logs:CreateLogGroup",
-      "logs:CreateLogStream",
-      "logs:PutLogEvents"
-    ]
-    resources = [
-      "arn:aws:logs:*:*:*"
-    ]
-  }
-
-  statement {
-    effect = "Allow"
-    actions = [
       "s3:*"
     ]
     resources = [
@@ -48,4 +36,9 @@ resource "aws_iam_policy" "lambda_api" {
 resource "aws_iam_role_policy_attachment" "lambda_api" {
   role       = aws_iam_role.lambda_api.name
   policy_arn = aws_iam_policy.lambda_api.arn
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_api_vpc_access_execution" {
+  role       = aws_iam_role.lambda_api.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
 }

--- a/modules/aws/lambda/main.tf
+++ b/modules/aws/lambda/main.tf
@@ -17,6 +17,11 @@ resource "aws_lambda_function" "api" {
   memory_size = 128
   timeout     = 900
 
+  vpc_config {
+    subnet_ids         = var.subnet_ids
+    security_group_ids = [aws_security_group.lambda.id]
+  }
+
   environment {
     variables = {
       REGION                 = data.aws_region.current.name
@@ -37,4 +42,23 @@ resource "aws_lambda_function" "api" {
 resource "aws_cloudwatch_log_group" "api" {
   name              = "/aws/lambda/${var.lambda_function_name}"
   retention_in_days = var.log_retention_in_days
+}
+
+resource "aws_security_group" "lambda" {
+  name        = "${var.lambda_function_name}-lambda"
+  description = "${var.lambda_function_name} Lambda Security Group"
+  vpc_id      = var.vpc_id
+
+  tags = {
+    Name = "${var.lambda_function_name}-lambda"
+  }
+}
+
+resource "aws_security_group_rule" "lambda_egress" {
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.lambda.id
 }

--- a/modules/aws/lambda/main.tf
+++ b/modules/aws/lambda/main.tf
@@ -27,6 +27,10 @@ resource "aws_lambda_function" "api" {
       REGION                 = data.aws_region.current.name
       UPLOAD_S3_BUCKET_NAME  = var.s3_bucket_name
       LGTM_IMAGES_CDN_DOMAIN = var.lgtm_images_cdn_domain
+      DB_HOSTNAME            = var.db_hostname
+      DB_PASSWORD            = var.db_password
+      DB_USERNAME            = var.db_username
+      DB_NAME                = var.db_name
     }
   }
 

--- a/modules/aws/lambda/outputs.tf
+++ b/modules/aws/lambda/outputs.tf
@@ -9,3 +9,7 @@ output "lambda_invoke_arn" {
 output "lambda_arn" {
   value = aws_lambda_function.api.arn
 }
+
+output "lambda_securitygroup_id" {
+  value = aws_security_group.lambda.id
+}

--- a/modules/aws/lambda/variables.tf
+++ b/modules/aws/lambda/variables.tf
@@ -29,3 +29,19 @@ variable "vpc_id" {
 variable "subnet_ids" {
   type = list(string)
 }
+
+variable "db_hostname" {
+  type = string
+}
+
+variable "db_password" {
+  type = string
+}
+
+variable "db_username" {
+  type = string
+}
+
+variable "db_name" {
+  type = string
+}

--- a/modules/aws/lambda/variables.tf
+++ b/modules/aws/lambda/variables.tf
@@ -21,3 +21,11 @@ variable "s3_bucket_name" {
 variable "lgtm_images_cdn_domain" {
   type = string
 }
+
+variable "vpc_id" {
+  type = string
+}
+
+variable "subnet_ids" {
+  type = list(string)
+}

--- a/modules/aws/rds/proxy.tf
+++ b/modules/aws/rds/proxy.tf
@@ -75,3 +75,12 @@ resource "aws_security_group_rule" "rds_from_stg_lambda" {
   protocol                 = "tcp"
   source_security_group_id = var.stg_lambda_securitygroup_id
 }
+
+resource "aws_security_group_rule" "rds_from_stg_api_lambda" {
+  security_group_id        = aws_security_group.rds_proxy.id
+  type                     = "ingress"
+  from_port                = "3306"
+  to_port                  = "3306"
+  protocol                 = "tcp"
+  source_security_group_id = var.stg_api_lambda_securitygroup_id
+}

--- a/modules/aws/rds/variables.tf
+++ b/modules/aws/rds/variables.tf
@@ -66,6 +66,10 @@ variable "stg_lambda_securitygroup_id" {
   type = string
 }
 
+variable "stg_api_lambda_securitygroup_id" {
+  type = string
+}
+
 variable "migration_ecs_securitygroup_id" {
   type = string
 }

--- a/modules/aws/vpc/main.tf
+++ b/modules/aws/vpc/main.tf
@@ -53,3 +53,13 @@ resource "aws_route_table_association" "public" {
     count.index,
   )
 }
+
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id       = aws_vpc.this.id
+  service_name = "com.amazonaws.ap-northeast-1.s3"
+}
+
+resource "aws_vpc_endpoint_route_table_association" "example" {
+  vpc_endpoint_id = aws_vpc_endpoint.s3.id
+  route_table_id  = aws_route_table.public.id
+}

--- a/providers/aws/environments/prod/23-rds/backend.tf
+++ b/providers/aws/environments/prod/23-rds/backend.tf
@@ -29,6 +29,17 @@ data "terraform_remote_state" "stg_lambda_securitygroup" {
   }
 }
 
+data "terraform_remote_state" "stg_api" {
+  backend = "s3"
+
+  config = {
+    bucket  = "stg-lgtm-cat-tfstate"
+    key     = "api/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "lgtm-cat"
+  }
+}
+
 data "terraform_remote_state" "migration" {
   backend = "s3"
 

--- a/providers/aws/environments/prod/23-rds/main.tf
+++ b/providers/aws/environments/prod/23-rds/main.tf
@@ -24,4 +24,5 @@ module "rds" {
   stg_app_password                   = local.stg_app_password
   stg_app_username                   = local.stg_app_username
   stg_migration_ecs_securitygroup_id = data.terraform_remote_state.stg_migration.outputs.migration_ecs_securitygroup_id
+  stg_api_lambda_securitygroup_id    = data.terraform_remote_state.stg_api.outputs.api_lambda_securitygroup_id
 }

--- a/providers/aws/environments/stg/20-api/backend.tf
+++ b/providers/aws/environments/stg/20-api/backend.tf
@@ -7,6 +7,17 @@ terraform {
   }
 }
 
+data "terraform_remote_state" "network" {
+  backend = "s3"
+
+  config = {
+    bucket  = "lgtm-cat-tfstate"
+    key     = "network/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "lgtm-cat"
+  }
+}
+
 data "terraform_remote_state" "acm" {
   backend = "s3"
 

--- a/providers/aws/environments/stg/20-api/main.tf
+++ b/providers/aws/environments/stg/20-api/main.tf
@@ -9,6 +9,10 @@ module "lambda" {
   lgtm_images_cdn_domain     = data.terraform_remote_state.images.outputs.lgtm_images_cdn_domain
   vpc_id                     = data.terraform_remote_state.network.outputs.vpc_id
   subnet_ids                 = data.terraform_remote_state.network.outputs.subnet_public_ids
+  db_hostname                = local.db_hostname
+  db_name                    = local.db_name
+  db_password                = local.db_password
+  db_username                = local.db_username
 }
 
 module "api_gateway" {

--- a/providers/aws/environments/stg/20-api/main.tf
+++ b/providers/aws/environments/stg/20-api/main.tf
@@ -7,6 +7,8 @@ module "lambda" {
   log_retention_in_days      = local.log_retention_in_days
   s3_bucket_name             = data.terraform_remote_state.images.outputs.upload_images_bucket_name
   lgtm_images_cdn_domain     = data.terraform_remote_state.images.outputs.lgtm_images_cdn_domain
+  vpc_id                     = data.terraform_remote_state.network.outputs.vpc_id
+  subnet_ids                 = data.terraform_remote_state.network.outputs.subnet_public_ids
 }
 
 module "api_gateway" {

--- a/providers/aws/environments/stg/20-api/outputs.tf
+++ b/providers/aws/environments/stg/20-api/outputs.tf
@@ -1,0 +1,3 @@
+output "api_lambda_securitygroup_id" {
+  value = module.lambda.lambda_securitygroup_id
+}

--- a/providers/aws/environments/stg/20-api/variables.tf
+++ b/providers/aws/environments/stg/20-api/variables.tf
@@ -13,6 +13,11 @@ locals {
   jwt_authorizer_name       = "${local.env}-jwt-authorizer"
   jwt_authorizer_issuer_url = "https://${data.terraform_remote_state.cognito.outputs.idp_endpoint}"
   lgtm_cat_bff_client_id    = data.terraform_remote_state.cognito.outputs.lgtm_cat_bff_client_id
+
+  db_password = jsondecode(data.aws_secretsmanager_secret_version.secret.secret_string)["db_app_password"]
+  db_username = jsondecode(data.aws_secretsmanager_secret_version.secret.secret_string)["db_app_user"]
+  db_name     = jsondecode(data.aws_secretsmanager_secret_version.secret.secret_string)["db_name"]
+  db_hostname = "lgtm-cat-rds-proxy.${local.env}"
 }
 
 variable "main_domain_name" {
@@ -22,4 +27,12 @@ variable "main_domain_name" {
 
 data "aws_route53_zone" "api" {
   name = var.main_domain_name
+}
+
+data "aws_secretsmanager_secret" "secret" {
+  name = "/stg/lgtm-cat"
+}
+
+data "aws_secretsmanager_secret_version" "secret" {
+  secret_id = data.aws_secretsmanager_secret.secret.id
 }


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-terraform/issues/56

# Doneの定義
https://github.com/nekochans/lgtm-cat-terraform/issues/56 の完了条件が満たされていること

# 変更点概要
API Lambda から RDS と S3 にアクセスできるよう下記の変更を行なった

- API 用の Lambda をVPC内部に変更
- VPC Lambda から S3 にアクセスするための VPC エンドポイントを作成
NAT gateway は構築していないので、VPC エンドポイントを利用して S3 にアクセスする
参考：[VPC の Lambda 関数へのインターネットアクセスを許可する](https://aws.amazon.com/jp/premiumsupport/knowledge-center/internet-access-lambda-function/)
> 注:Amazon VPC エンドポイントを使用して、インターネットにアクセスせずに Amazon VPC 内からサポートされている AWS のサービスに接続することもできます。

- API 用の Lambda から RDS Proxy に接続するために SecurityGroup ingress ルールを追加
- API Lambda が RDS Proxy に接続する際に必要となるDB接続情報を Lambda の環境変数に追加

##