### PR TITLE
画像アップロード機能に必要な本番用リソースの構築を行う

### DIFF
--- a/modules/aws/rds/proxy.tf
+++ b/modules/aws/rds/proxy.tf
@@ -67,6 +67,15 @@ resource "aws_security_group_rule" "rds_proxy_from_bastion_server" {
   source_security_group_id = aws_security_group.bastion_ecs.id
 }
 
+resource "aws_security_group_rule" "rds_from_api_lambda" {
+  security_group_id        = aws_security_group.rds_proxy.id
+  type                     = "ingress"
+  from_port                = "3306"
+  to_port                  = "3306"
+  protocol                 = "tcp"
+  source_security_group_id = var.api_lambda_securitygroup_id
+}
+
 resource "aws_security_group_rule" "rds_from_stg_lambda" {
   security_group_id        = aws_security_group.rds_proxy.id
   type                     = "ingress"

--- a/modules/aws/rds/proxy.tf
+++ b/modules/aws/rds/proxy.tf
@@ -5,7 +5,7 @@ resource "aws_db_proxy" "rds_proxy" {
   idle_client_timeout    = 120
   require_tls            = false
   role_arn               = aws_iam_role.rds_proxy_role.arn
-  vpc_security_group_ids = [aws_security_group.rds_proxy.id]
+  vpc_security_group_ids = [aws_security_group.rds_proxy.id, aws_security_group.rds_proxy_stg.id]
   vpc_subnet_ids         = var.subnet_ids
 
   auth {
@@ -76,8 +76,27 @@ resource "aws_security_group_rule" "rds_from_api_lambda" {
   source_security_group_id = var.api_lambda_securitygroup_id
 }
 
+resource "aws_security_group" "rds_proxy_stg" {
+  name        = "stg-${var.rds_name}-rds-proxy"
+  description = "${var.rds_name} RDS Proxy Security Group for stg"
+  vpc_id      = var.vpc_id
+
+  tags = {
+    Name = "stg-${var.rds_name}-rds-proxy"
+  }
+}
+
+resource "aws_security_group_rule" "rds_proxy_egress_stg" {
+  security_group_id = aws_security_group.rds_proxy_stg.id
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
 resource "aws_security_group_rule" "rds_from_stg_lambda" {
-  security_group_id        = aws_security_group.rds_proxy.id
+  security_group_id        = aws_security_group.rds_proxy_stg.id
   type                     = "ingress"
   from_port                = "3306"
   to_port                  = "3306"
@@ -86,7 +105,7 @@ resource "aws_security_group_rule" "rds_from_stg_lambda" {
 }
 
 resource "aws_security_group_rule" "rds_from_stg_api_lambda" {
-  security_group_id        = aws_security_group.rds_proxy.id
+  security_group_id        = aws_security_group.rds_proxy_stg.id
   type                     = "ingress"
   from_port                = "3306"
   to_port                  = "3306"

--- a/modules/aws/rds/variables.tf
+++ b/modules/aws/rds/variables.tf
@@ -62,6 +62,10 @@ variable "proxy_engine" {
   type = string
 }
 
+variable "api_lambda_securitygroup_id" {
+  type = string
+}
+
 variable "stg_lambda_securitygroup_id" {
   type = string
 }

--- a/providers/aws/environments/prod/12-images/outputs.tf
+++ b/providers/aws/environments/prod/12-images/outputs.tf
@@ -5,3 +5,7 @@ output "upload_images_bucket_name" {
 output "lgtm_images_bucket_name" {
   value = module.images.lgtm_images_bucket_name
 }
+
+output "lgtm_images_cdn_domain" {
+  value = local.lgtm_images_cdn_domain
+}

--- a/providers/aws/environments/prod/20-api/.terraform.lock.hcl
+++ b/providers/aws/environments/prod/20-api/.terraform.lock.hcl
@@ -1,0 +1,38 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.2.0"
+  hashes = [
+    "h1:CIWi5G6ob7p2wWoThRQbOB8AbmFlCzp7Ka81hR3cVp0=",
+    "zh:06bd875932288f235c16e2237142b493c2c2b6aba0e82e8c85068332a8d2a29e",
+    "zh:0c681b481372afcaefddacc7ccdf1d3bb3a0c0d4678a526bc8b02d0c331479bc",
+    "zh:100fc5b3fc01ea463533d7bbfb01cb7113947a969a4ec12e27f5b2be49884d6c",
+    "zh:55c0d7ddddbd0a46d57c51fcfa9b91f14eed081a45101dbfc7fd9d2278aa1403",
+    "zh:73a5dd68379119167934c48afa1101b09abad2deb436cd5c446733e705869d6b",
+    "zh:841fc4ac6dc3479981330974d44ad2341deada8a5ff9e3b1b4510702dfbdbed9",
+    "zh:91be62c9b41edb137f7f835491183628d484e9d6efa82fcb75cfa538c92791c5",
+    "zh:acd5f442bd88d67eb948b18dc2ed421c6c3faee62d3a12200e442bfff0aa7d8b",
+    "zh:ad5720da5524641ad718a565694821be5f61f68f1c3c5d2cfa24426b8e774bef",
+    "zh:e63f12ea938520b3f83634fc29da28d92eed5cfbc5cc8ca08281a6a9c36cca65",
+    "zh:f6542918faa115df46474a36aabb4c3899650bea036b5f8a5e296be6f8f25767",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.29.0"
+  constraints = "3.29.0"
+  hashes = [
+    "h1:euXiL7Q/8CZ7eFO8ktcDVNEV51tJpicreQGazmNSGCg=",
+    "zh:0e3ec82025efcfed94180858240a1be147bc3eabb24a755f8c58970173b71e54",
+    "zh:22897ef5b00317ffa2495a5582c567a4ceca09e9071e0888b18c8364bab6d31b",
+    "zh:2e98fc511787045e5ef6f0e76d92ea8de27cd168b20902f9e57d75c96dcb80d8",
+    "zh:4e86f7f25c27c139ae17e3ad2a82a154b115d83f16bf8d8fee2aba9f00c80437",
+    "zh:71ba0b2b10a5e83b276ebca1d8559354c12656310bfd2554591ac6f0f5541bd0",
+    "zh:771989dadb5921bf4586c749a537116eaafdd854e542c5890c9dac55d7b2f8ac",
+    "zh:7aa3095c12174b6f8f525ba6007312df6b95de4b4137d25414144e7731ac202c",
+    "zh:a1c6f9a6f1abee0cc9c4a3a912c0e6571e7cc439701f03172de44b4187e66769",
+    "zh:bd50937e68e9434fc482817e9acfe486b95c69494194627884091a0581a0dffd",
+    "zh:e035fd1df86f709374a8547ac141edd1bd899cc7d979b7b28da3ad62fa6ff47b",
+  ]
+}

--- a/providers/aws/environments/prod/20-api/backend.tf
+++ b/providers/aws/environments/prod/20-api/backend.tf
@@ -1,0 +1,52 @@
+terraform {
+  backend "s3" {
+    bucket  = "lgtm-cat-tfstate"
+    key     = "api/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "lgtm-cat"
+  }
+}
+
+data "terraform_remote_state" "network" {
+  backend = "s3"
+
+  config = {
+    bucket  = "lgtm-cat-tfstate"
+    key     = "network/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "lgtm-cat"
+  }
+}
+
+data "terraform_remote_state" "acm" {
+  backend = "s3"
+
+  config = {
+    bucket  = "lgtm-cat-tfstate"
+    key     = "acm/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "lgtm-cat"
+  }
+}
+
+data "terraform_remote_state" "images" {
+  backend = "s3"
+
+  config = {
+    bucket  = "lgtm-cat-tfstate"
+    key     = "images/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "lgtm-cat"
+  }
+}
+
+data "terraform_remote_state" "cognito" {
+  backend = "s3"
+
+  config = {
+    bucket  = "lgtm-cat-tfstate"
+    key     = "cognito/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "lgtm-cat"
+  }
+}

--- a/providers/aws/environments/prod/20-api/main.tf
+++ b/providers/aws/environments/prod/20-api/main.tf
@@ -1,0 +1,34 @@
+module "lambda" {
+  source = "../../../../../modules/aws/lambda"
+
+  lambda_function_name       = local.lambda_function_name
+  lambda_api_iam_policy_name = local.lambda_api_iam_policy_name
+  lambda_api_iam_role_name   = local.lambda_api_iam_role_name
+  log_retention_in_days      = local.log_retention_in_days
+  s3_bucket_name             = data.terraform_remote_state.images.outputs.upload_images_bucket_name
+  lgtm_images_cdn_domain     = data.terraform_remote_state.images.outputs.lgtm_images_cdn_domain
+  vpc_id                     = data.terraform_remote_state.network.outputs.vpc_id
+  subnet_ids                 = data.terraform_remote_state.network.outputs.subnet_public_ids
+  db_hostname                = local.db_hostname
+  db_name                    = local.db_name
+  db_password                = local.db_password
+  db_username                = local.db_username
+}
+
+module "api_gateway" {
+  source = "../../../../../modules/aws/api-gateway"
+
+  lambda_function_name      = module.lambda.lambda_function_name
+  lambda_invoke_arn         = module.lambda.lambda_invoke_arn
+  lambda_arn                = module.lambda.lambda_arn
+  api_gateway_name          = local.api_gateway_name
+  api_gateway_domain_name   = local.api_gateway_domain_name
+  auto_deploy               = local.auto_deploy
+  certificate_arn           = local.certificate_arn
+  zone_id                   = data.aws_route53_zone.api.zone_id
+  jwt_authorizer_name       = local.jwt_authorizer_name
+  jwt_authorizer_issuer_url = local.jwt_authorizer_issuer_url
+  lgtm_cat_bff_client_id    = local.lgtm_cat_bff_client_id
+
+  depends_on = [module.lambda]
+}

--- a/providers/aws/environments/prod/20-api/outputs.tf
+++ b/providers/aws/environments/prod/20-api/outputs.tf
@@ -1,0 +1,3 @@
+output "api_lambda_securitygroup_id" {
+  value = module.lambda.lambda_securitygroup_id
+}

--- a/providers/aws/environments/prod/20-api/provider.tf
+++ b/providers/aws/environments/prod/20-api/provider.tf
@@ -1,0 +1,6 @@
+provider "aws" {
+  region  = "ap-northeast-1"
+  profile = "lgtm-cat"
+}
+
+provider "archive" {}

--- a/providers/aws/environments/prod/20-api/variables.tf
+++ b/providers/aws/environments/prod/20-api/variables.tf
@@ -1,0 +1,38 @@
+locals {
+  env = "prod"
+
+  lambda_function_name       = "${local.env}-lgtm-cat-api"
+  lambda_api_iam_policy_name = "${local.env}-lgtm-cat-api-policy"
+  lambda_api_iam_role_name   = "${local.env}-lgtm-cat-api-role"
+  log_retention_in_days      = 3
+
+  api_gateway_name          = "${local.env}-lgtm-cat-api"
+  auto_deploy               = true
+  api_gateway_domain_name   = "api.${var.main_domain_name}"
+  certificate_arn           = data.terraform_remote_state.acm.outputs.ap_northeast_1_sub_domain_acm_arn
+  jwt_authorizer_name       = "${local.env}-jwt-authorizer"
+  jwt_authorizer_issuer_url = "https://${data.terraform_remote_state.cognito.outputs.idp_endpoint}"
+  lgtm_cat_bff_client_id    = data.terraform_remote_state.cognito.outputs.lgtm_cat_bff_client_id
+
+  db_password = jsondecode(data.aws_secretsmanager_secret_version.secret.secret_string)["db_app_password"]
+  db_username = jsondecode(data.aws_secretsmanager_secret_version.secret.secret_string)["db_app_user"]
+  db_name     = jsondecode(data.aws_secretsmanager_secret_version.secret.secret_string)["db_name"]
+  db_hostname = "lgtm-cat-rds-proxy.${local.env}"
+}
+
+variable "main_domain_name" {
+  type    = string
+  default = "lgtmeow.com"
+}
+
+data "aws_route53_zone" "api" {
+  name = var.main_domain_name
+}
+
+data "aws_secretsmanager_secret" "secret" {
+  name = "/prod/lgtm-cat"
+}
+
+data "aws_secretsmanager_secret_version" "secret" {
+  secret_id = data.aws_secretsmanager_secret.secret.id
+}

--- a/providers/aws/environments/prod/20-api/versions.tf
+++ b/providers/aws/environments/prod/20-api/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = "1.0.3"
+
+  required_providers {
+    aws = "3.29.0"
+  }
+}

--- a/providers/aws/environments/prod/23-rds/backend.tf
+++ b/providers/aws/environments/prod/23-rds/backend.tf
@@ -18,6 +18,17 @@ data "terraform_remote_state" "network" {
   }
 }
 
+data "terraform_remote_state" "api" {
+  backend = "s3"
+
+  config = {
+    bucket  = "lgtm-cat-tfstate"
+    key     = "api/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "lgtm-cat"
+  }
+}
+
 data "terraform_remote_state" "stg_lambda_securitygroup" {
   backend = "s3"
 

--- a/providers/aws/environments/prod/23-rds/main.tf
+++ b/providers/aws/environments/prod/23-rds/main.tf
@@ -20,6 +20,7 @@ module "rds" {
   app_password                   = local.app_password
   app_username                   = local.app_username
   migration_ecs_securitygroup_id = data.terraform_remote_state.migration.outputs.migration_ecs_securitygroup_id
+  api_lambda_securitygroup_id    = data.terraform_remote_state.api.outputs.api_lambda_securitygroup_id
 
   // STG用
   stg_app_password                   = local.stg_app_password

--- a/providers/aws/environments/prod/23-rds/main.tf
+++ b/providers/aws/environments/prod/23-rds/main.tf
@@ -1,28 +1,30 @@
 module "rds" {
   source = "../../../../../modules/aws/rds"
 
-  rds_name                       = local.rds_name
-  engine                         = local.engine
-  engine_version                 = local.engine_version
-  master_password                = local.master_password
-  master_username                = local.master_username
-  instance_class                 = local.instance_class
-  cluster_availability_zones     = local.cluster_availability_zones
-  instance_availability_zones    = local.instance_availability_zones
-  parameter_group_family         = local.parameter_group_family
-  vpc_id                         = data.terraform_remote_state.network.outputs.vpc_id
-  subnet_ids                     = data.terraform_remote_state.network.outputs.subnet_public_ids
-  proxy_engine                   = local.proxy_engine
+  rds_name                    = local.rds_name
+  engine                      = local.engine
+  engine_version              = local.engine_version
+  master_password             = local.master_password
+  master_username             = local.master_username
+  instance_class              = local.instance_class
+  cluster_availability_zones  = local.cluster_availability_zones
+  instance_availability_zones = local.instance_availability_zones
+  parameter_group_family      = local.parameter_group_family
+  vpc_id                      = data.terraform_remote_state.network.outputs.vpc_id
+  subnet_ids                  = data.terraform_remote_state.network.outputs.subnet_public_ids
+  proxy_engine                = local.proxy_engine
+  rds_domain_name             = local.rds_domain_name
+  rds_proxy_domain_name       = local.rds_proxy_domain_name
+
+  // PROD用
   app_password                   = local.app_password
   app_username                   = local.app_username
   migration_ecs_securitygroup_id = data.terraform_remote_state.migration.outputs.migration_ecs_securitygroup_id
-  rds_domain_name                = local.rds_domain_name
-  rds_proxy_domain_name          = local.rds_proxy_domain_name
 
   // STG用
-  stg_lambda_securitygroup_id        = data.terraform_remote_state.stg_lambda_securitygroup.outputs.lambda_security_group_id
   stg_app_password                   = local.stg_app_password
   stg_app_username                   = local.stg_app_username
   stg_migration_ecs_securitygroup_id = data.terraform_remote_state.stg_migration.outputs.migration_ecs_securitygroup_id
+  stg_lambda_securitygroup_id        = data.terraform_remote_state.stg_lambda_securitygroup.outputs.lambda_security_group_id
   stg_api_lambda_securitygroup_id    = data.terraform_remote_state.stg_api.outputs.api_lambda_securitygroup_id
 }

--- a/terraform-init.sh
+++ b/terraform-init.sh
@@ -9,6 +9,7 @@ tfstateDirList='
 /data/providers/aws/environments/prod/15-iam
 /data/providers/aws/environments/prod/16-ses
 /data/providers/aws/environments/prod/17-cognito
+/data/providers/aws/environments/prod/20-api
 /data/providers/aws/environments/prod/22-migration
 /data/providers/aws/environments/prod/23-rds
 /data/providers/aws/environments/stg/11-acm


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-terraform/issues/41

# Doneの定義
https://github.com/nekochans/lgtm-cat-terraform/issues/41 の完了の条件が満たされていること

# 変更点概要
画像アップロード機能に必要な本番用リソースの構築を行なった。
具体的な変更内容は下記の通り。

- `prod/20-api` ディレクトリを追加し、下記のリソースを構築
    - API Gateway
    - Lambda (Terrform で Lambda を作成後、https://github.com/nekochans/lgtm-cat-api からデプロイを行う)
    - terraform-init.sh もディレクトリ追加に合わせて更新
- ` modules/aws/rds` に変更
    - PROD API Lambda から RDS Proxy に接続できるように SecurityGroup ingress ルールを追加
    - RDS Cluster, RDS Proxy のセキュリティグループをSTG、PRODで共通にしていたが、環境ごとに分けたが方がセキュリティ的に安全だと判断しSTGの設定用のセキュリティグループを作成