### PR TITLE
本番用に lgtm-cat-lambda のセキュリティグループを作成

### DIFF
--- a/providers/aws/environments/prod/21-lambda-securitygroup/.terraform.lock.hcl
+++ b/providers/aws/environments/prod/21-lambda-securitygroup/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.29.0"
+  constraints = "3.29.0"
+  hashes = [
+    "h1:euXiL7Q/8CZ7eFO8ktcDVNEV51tJpicreQGazmNSGCg=",
+    "zh:0e3ec82025efcfed94180858240a1be147bc3eabb24a755f8c58970173b71e54",
+    "zh:22897ef5b00317ffa2495a5582c567a4ceca09e9071e0888b18c8364bab6d31b",
+    "zh:2e98fc511787045e5ef6f0e76d92ea8de27cd168b20902f9e57d75c96dcb80d8",
+    "zh:4e86f7f25c27c139ae17e3ad2a82a154b115d83f16bf8d8fee2aba9f00c80437",
+    "zh:71ba0b2b10a5e83b276ebca1d8559354c12656310bfd2554591ac6f0f5541bd0",
+    "zh:771989dadb5921bf4586c749a537116eaafdd854e542c5890c9dac55d7b2f8ac",
+    "zh:7aa3095c12174b6f8f525ba6007312df6b95de4b4137d25414144e7731ac202c",
+    "zh:a1c6f9a6f1abee0cc9c4a3a912c0e6571e7cc439701f03172de44b4187e66769",
+    "zh:bd50937e68e9434fc482817e9acfe486b95c69494194627884091a0581a0dffd",
+    "zh:e035fd1df86f709374a8547ac141edd1bd899cc7d979b7b28da3ad62fa6ff47b",
+  ]
+}

--- a/providers/aws/environments/prod/21-lambda-securitygroup/backend.tf
+++ b/providers/aws/environments/prod/21-lambda-securitygroup/backend.tf
@@ -1,0 +1,19 @@
+terraform {
+  backend "s3" {
+    bucket  = "lgtm-cat-tfstate"
+    key     = "lambda-securitygroup/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "lgtm-cat"
+  }
+}
+
+data "terraform_remote_state" "network" {
+  backend = "s3"
+
+  config = {
+    bucket  = "lgtm-cat-tfstate"
+    key     = "network/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "lgtm-cat"
+  }
+}

--- a/providers/aws/environments/prod/21-lambda-securitygroup/main.tf
+++ b/providers/aws/environments/prod/21-lambda-securitygroup/main.tf
@@ -1,0 +1,7 @@
+module "lambda" {
+  source = "../../../../../modules/aws/lambda-securitygroup"
+
+  vpc_id               = data.terraform_remote_state.network.outputs.vpc_id
+  lambda_function_name = local.lambda_function_name
+}
+

--- a/providers/aws/environments/prod/21-lambda-securitygroup/outputs.tf
+++ b/providers/aws/environments/prod/21-lambda-securitygroup/outputs.tf
@@ -1,0 +1,3 @@
+output "lambda_security_group_id" {
+  value = module.lambda.lambda_security_group_id
+}

--- a/providers/aws/environments/prod/21-lambda-securitygroup/provider.tf
+++ b/providers/aws/environments/prod/21-lambda-securitygroup/provider.tf
@@ -1,0 +1,4 @@
+provider "aws" {
+  region  = "ap-northeast-1"
+  profile = "lgtm-cat"
+}

--- a/providers/aws/environments/prod/21-lambda-securitygroup/variables.tf
+++ b/providers/aws/environments/prod/21-lambda-securitygroup/variables.tf
@@ -1,0 +1,6 @@
+locals {
+  env                  = "prod"
+  lambda_function_name = "${local.env}-store-lgtm-image"
+}
+
+

--- a/providers/aws/environments/prod/21-lambda-securitygroup/versions.tf
+++ b/providers/aws/environments/prod/21-lambda-securitygroup/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = "1.0.3"
+
+  required_providers {
+    aws = "3.29.0"
+  }
+}

--- a/terraform-init.sh
+++ b/terraform-init.sh
@@ -10,6 +10,7 @@ tfstateDirList='
 /data/providers/aws/environments/prod/16-ses
 /data/providers/aws/environments/prod/17-cognito
 /data/providers/aws/environments/prod/20-api
+/data/providers/aws/environments/prod/21-lambda-securitygroup
 /data/providers/aws/environments/prod/22-migration
 /data/providers/aws/environments/prod/23-rds
 /data/providers/aws/environments/stg/11-acm


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-terraform/issues/58

# Doneの定義
https://github.com/nekochans/lgtm-cat-terraform/issues/58 の完了の定義が満たされていること

# 変更点概要
- `providers/aws/environments/prod/21-lambda-securitygroup`ディレクトリを作成し、本番用に lgtm-cat-lambda のセキュリティグループを作成
- ディレクトリを追加したので、`terraform-init.sh`も更新
