### PR TITLE
API 用の Lambda のタイムアウトを API Gateway のタイムアウトより短くするために29秒に変更

### DIFF
--- a/modules/aws/lambda/main.tf
+++ b/modules/aws/lambda/main.tf
@@ -15,7 +15,7 @@ resource "aws_lambda_function" "api" {
   runtime          = "go1.x"
 
   memory_size = 128
-  timeout     = 900
+  timeout     = 29
 
   vpc_config {
     subnet_ids         = var.subnet_ids


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-terraform/issues/61

# Doneの定義
API LambdaのタイムアウトをAPI Gatewayのタイムアウトより短くなっていること

# 変更点概要
Lambda のタイムアウトを29秒に変更

# 補足情報
STG,PROD 共にapply実行済み。