### PR TITLE
Lambda から RDS Proxy に接続できるよう SecurityGroup に ingress ルールを追加

### DIFF
--- a/modules/aws/rds/proxy.tf
+++ b/modules/aws/rds/proxy.tf
@@ -67,6 +67,15 @@ resource "aws_security_group_rule" "rds_proxy_from_bastion_server" {
   source_security_group_id = aws_security_group.bastion_ecs.id
 }
 
+resource "aws_security_group_rule" "rds_from_lambda" {
+  security_group_id        = aws_security_group.rds_proxy.id
+  type                     = "ingress"
+  from_port                = "3306"
+  to_port                  = "3306"
+  protocol                 = "tcp"
+  source_security_group_id = var.lambda_securitygroup_id
+}
+
 resource "aws_security_group_rule" "rds_from_api_lambda" {
   security_group_id        = aws_security_group.rds_proxy.id
   type                     = "ingress"

--- a/modules/aws/rds/variables.tf
+++ b/modules/aws/rds/variables.tf
@@ -62,6 +62,10 @@ variable "proxy_engine" {
   type = string
 }
 
+variable "lambda_securitygroup_id" {
+  type = string
+}
+
 variable "api_lambda_securitygroup_id" {
   type = string
 }

--- a/providers/aws/environments/prod/23-rds/backend.tf
+++ b/providers/aws/environments/prod/23-rds/backend.tf
@@ -18,6 +18,17 @@ data "terraform_remote_state" "network" {
   }
 }
 
+data "terraform_remote_state" "lambda_securitygroup" {
+  backend = "s3"
+
+  config = {
+    bucket  = "lgtm-cat-tfstate"
+    key     = "lambda-securitygroup/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "lgtm-cat"
+  }
+}
+
 data "terraform_remote_state" "api" {
   backend = "s3"
 

--- a/providers/aws/environments/prod/23-rds/main.tf
+++ b/providers/aws/environments/prod/23-rds/main.tf
@@ -20,6 +20,7 @@ module "rds" {
   app_password                   = local.app_password
   app_username                   = local.app_username
   migration_ecs_securitygroup_id = data.terraform_remote_state.migration.outputs.migration_ecs_securitygroup_id
+  lambda_securitygroup_id        = data.terraform_remote_state.lambda_securitygroup.outputs.lambda_security_group_id
   api_lambda_securitygroup_id    = data.terraform_remote_state.api.outputs.api_lambda_securitygroup_id
 
   // STG用


### PR DESCRIPTION
# issueURL
なし

# Doneの定義
Lambda から RDS Proxy に接続できること

# 変更点概要
Lambda から RDS Proxy に接続できるよう SecurityGroup に ingress ルールを追加

# 補足情報
prod 環境に apply 実行済み。