### PR TITLE
ねこ画像と判定された画像は永続的に残すように変更

### DIFF
--- a/modules/aws/images/main.tf
+++ b/modules/aws/images/main.tf
@@ -33,11 +33,11 @@ resource "aws_s3_bucket" "cat_images_bucket" {
   lifecycle_rule {
     enabled = true
     // 失効した削除マーカーまたは不完全なマルチパートアップロードを削除する
-    abort_incomplete_multipart_upload_days = 1
+    abort_incomplete_multipart_upload_days = 7
 
-    // オブジェクトの有効期限
-    expiration {
-      days = 10
+    // 古いバージョンは30日で削除
+    noncurrent_version_expiration {
+      days = 30
     }
   }
 }


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-terraform/issues/64

# 関連URL
なし

# Doneの定義
- https://github.com/nekochans/lgtm-cat-terraform/issues/64 のDoneの定義を満たしている事

# 変更点概要
表題の通りで `lgtm_images_bucket` と同様にオブジェクトの有効期限を削除して永続的に画像を残すように変更。

# 補足情報

本来は最初からこうしておきたかったが設定ミスによりそうなっていなかった。