### PR TITLE
CloudFront セキュリティポリシーを最新のポリシーに変更

### DIFF
--- a/modules/aws/images/main.tf
+++ b/modules/aws/images/main.tf
@@ -184,7 +184,7 @@ resource "aws_cloudfront_distribution" "lgtm_images_cdn" {
 
   viewer_certificate {
     acm_certificate_arn      = var.lgtm_images_cdn_acm_arn
-    minimum_protocol_version = "TLSv1.2_2019"
+    minimum_protocol_version = "TLSv1.2_2021"
     ssl_support_method       = "sni-only"
   }
 }


### PR DESCRIPTION
# issueURL
#66 

# Doneの定義
#66 の完了条件が満たされていること

# 変更点概要
CloudFront セキュリティポリシーを最新のポリシー `TLSv1.2_2021` に変更

# 補足情報
STGにapplyして画像が表示されることを確認済み。