### PR TITLE
terraform-init.sh のディレクトリ一覧をshell内部で取得するように変更

### DIFF
--- a/terraform-init.sh
+++ b/terraform-init.sh
@@ -1,30 +1,13 @@
 #!/bin/sh
 
-tfstateDirList='
-/data/providers/aws/environments/prod/10-network
-/data/providers/aws/environments/prod/11-acm
-/data/providers/aws/environments/prod/12-images
-/data/providers/aws/environments/prod/13-vercel
-/data/providers/aws/environments/prod/14-txt
-/data/providers/aws/environments/prod/15-iam
-/data/providers/aws/environments/prod/16-ses
-/data/providers/aws/environments/prod/17-cognito
-/data/providers/aws/environments/prod/20-api
-/data/providers/aws/environments/prod/21-lambda-securitygroup
-/data/providers/aws/environments/prod/22-migration
-/data/providers/aws/environments/prod/23-rds
-/data/providers/aws/environments/stg/11-acm
-/data/providers/aws/environments/stg/12-images
-/data/providers/aws/environments/stg/17-cognito
-/data/providers/aws/environments/stg/20-api
-/data/providers/aws/environments/stg/21-lambda-securitygroup
-/data/providers/aws/environments/stg/22-migration
-'
+currentDir=$(pwd)
 
-for tfstateDir in ${tfstateDirList}; do
+for tfstateDir in $(find . -maxdepth 5 -regex "\./providers.*/[0-9]\{2,\}.*" -type d); do
   echo "$tfstateDir"
   # shellcheck disable=SC2164
   cd "$tfstateDir"
   pwd
   terraform init
+  # shellcheck disable=SC2164
+  cd "$currentDir"
 done


### PR DESCRIPTION
# issueURL
#70 

# Doneの定義
#70 の完了の定義が満たされていること

# 変更点概要
terraform-init.sh のディレクトリ一覧をshell内部で取得するように変更。

作業ディレクトリを追加した際に terraform-init.sh の更新をよく忘れてしまうので、terraform-init.sh を更新しなくていいように変更を行った。また、ディレクトリ構成が大きく変わることはなさそうなので、正規表現で取得する形で問題ないかなと思ってこの形にしている。