### PR TITLE
lgtm-cat-apiのAPIGatewayにCORSの設定を追加

### DIFF
--- a/modules/aws/api-gateway/http-api.tf
+++ b/modules/aws/api-gateway/http-api.tf
@@ -2,6 +2,13 @@ resource "aws_apigatewayv2_api" "api" {
   name          = var.api_gateway_name
   protocol_type = "HTTP"
   target        = var.lambda_arn
+
+  cors_configuration {
+    allow_credentials = true
+    allow_headers     = ["authorization", "content-type"]
+    allow_methods     = ["GET", "POST", "PUT", "DELETE", "OPTIONS"]
+    allow_origins     = var.api_allow_origins
+  }
 }
 
 resource "aws_apigatewayv2_authorizer" "jwt_authorizer" {

--- a/modules/aws/api-gateway/http-api.tf
+++ b/modules/aws/api-gateway/http-api.tf
@@ -24,6 +24,13 @@ resource "aws_apigatewayv2_route" "api" {
   authorizer_id      = aws_apigatewayv2_authorizer.jwt_authorizer.id
 }
 
+resource "aws_apigatewayv2_route" "api_options_route" {
+  api_id             = aws_apigatewayv2_api.api.id
+  route_key          = "OPTIONS /{proxy+}"
+  target             = "integrations/${aws_apigatewayv2_integration.api.id}"
+  authorization_type = "NONE"
+}
+
 resource "aws_apigatewayv2_integration" "api" {
   api_id = aws_apigatewayv2_api.api.id
 

--- a/modules/aws/api-gateway/variables.tf
+++ b/modules/aws/api-gateway/variables.tf
@@ -40,3 +40,7 @@ variable "jwt_authorizer_issuer_url" {
 variable "lgtm_cat_bff_client_id" {
   type = string
 }
+
+variable "api_allow_origins" {
+  type = list(string)
+}

--- a/providers/aws/environments/prod/20-api/main.tf
+++ b/providers/aws/environments/prod/20-api/main.tf
@@ -29,6 +29,7 @@ module "api_gateway" {
   jwt_authorizer_name       = local.jwt_authorizer_name
   jwt_authorizer_issuer_url = local.jwt_authorizer_issuer_url
   lgtm_cat_bff_client_id    = local.lgtm_cat_bff_client_id
+  api_allow_origins         = var.api_allow_origins
 
   depends_on = [module.lambda]
 }

--- a/providers/aws/environments/prod/20-api/variables.tf
+++ b/providers/aws/environments/prod/20-api/variables.tf
@@ -36,3 +36,8 @@ data "aws_secretsmanager_secret" "secret" {
 data "aws_secretsmanager_secret_version" "secret" {
   secret_id = data.aws_secretsmanager_secret.secret.id
 }
+
+variable "api_allow_origins" {
+  type    = list(string)
+  default = ["https://lgtmeow.com"]
+}

--- a/providers/aws/environments/stg/20-api/main.tf
+++ b/providers/aws/environments/stg/20-api/main.tf
@@ -29,6 +29,7 @@ module "api_gateway" {
   jwt_authorizer_name       = local.jwt_authorizer_name
   jwt_authorizer_issuer_url = local.jwt_authorizer_issuer_url
   lgtm_cat_bff_client_id    = local.lgtm_cat_bff_client_id
+  api_allow_origins         = var.api_allow_origins
 
   depends_on = [module.lambda]
 }

--- a/providers/aws/environments/stg/20-api/variables.tf
+++ b/providers/aws/environments/stg/20-api/variables.tf
@@ -36,3 +36,8 @@ data "aws_secretsmanager_secret" "secret" {
 data "aws_secretsmanager_secret_version" "secret" {
   secret_id = data.aws_secretsmanager_secret.secret.id
 }
+
+variable "api_allow_origins" {
+  type    = list(string)
+  default = ["https://*", "http://localhost:2222"]
+}


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-terraform/issues/72

# 関連URL
なし

# Doneの定義
- lgtm-cat-apiがPreflightリクエストを受け取れるようになっている事

# 変更点概要

https://docs.aws.amazon.com/ja_jp/apigateway/latest/developerguide/http-api-cors.html のドキュメントに従い、`OPTIONS /{proxy+}` ルートを追加。

API側の `OPTIONS` ルートの設定は `github.com/go-chi/cors` を利用するようにした。対応PRは https://github.com/nekochans/lgtm-cat-api/pull/34

理由としてはローカル環境から将来的に作成されるであろう lgtm-cat-apiのローカルサーバーに通信する可能性もある為、そこでCORSのHeaderが設定されていないと結合して動作確認する際に不都合が発生すると判断した為。

# レビュアーに重点的にチェックして欲しい点
関連PRを含めて方針問題ないか確認してもらえると:pray:

# 補足情報
本件は https://github.com/nekochans/lgtm-cat-frontend/issues/146 の解決の為に実施している。