### PR TITLE
lgtm-cat-api 用の ECS を構築

### DIFF
--- a/modules/aws/ecs/alb.tf
+++ b/modules/aws/ecs/alb.tf
@@ -1,0 +1,38 @@
+resource "aws_alb" "api_public" {
+  name               = var.name
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.api_public_alb.id]
+
+  subnets = var.subnet_public_ids
+}
+
+resource "aws_alb_target_group" "api_public" {
+  name        = var.name
+  port        = 80
+  protocol    = "HTTP"
+  vpc_id      = var.vpc_id
+  target_type = "ip"
+
+  health_check {
+    path                = "/health-checks"
+    timeout             = 5
+    healthy_threshold   = 5
+    unhealthy_threshold = 2
+    interval            = 20
+    matcher             = 200
+  }
+}
+
+resource "aws_alb_listener" "api_public" {
+  default_action {
+    target_group_arn = aws_alb_target_group.api_public.id
+    type             = "forward"
+  }
+
+  load_balancer_arn = aws_alb.api_public.id
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS-1-2-Ext-2018-06"
+  certificate_arn   = var.certificate_arn
+}

--- a/modules/aws/ecs/cloudwatch.tf
+++ b/modules/aws/ecs/cloudwatch.tf
@@ -1,0 +1,9 @@
+resource "aws_cloudwatch_log_group" "api_app_log" {
+  name              = "${var.name}-app"
+  retention_in_days = var.log_retention_in_days
+}
+
+resource "aws_cloudwatch_log_group" "api_nginx_log" {
+  name              = "${var.name}-nginx"
+  retention_in_days = var.log_retention_in_days
+}

--- a/modules/aws/ecs/ecr.tf
+++ b/modules/aws/ecs/ecr.tf
@@ -1,0 +1,39 @@
+resource "aws_ecr_repository" "api_app" {
+  name = "${var.name}-app"
+}
+
+resource "aws_ecr_repository" "api_nginx" {
+  name = "${var.name}-nginx"
+}
+
+locals {
+  lifecycle_policy = <<EOF
+  {
+    "rules": [
+      {
+        "rulePriority": 10,
+        "description": "Expire images count more than 5",
+        "selection": {
+          "tagStatus": "any",
+          "countType": "imageCountMoreThan",
+          "countNumber": 5
+        },
+        "action": {
+          "type": "expire"
+        }
+      }
+    ]
+  }
+EOF
+
+}
+
+resource "aws_ecr_lifecycle_policy" "api_app" {
+  repository = aws_ecr_repository.api_app.name
+  policy     = local.lifecycle_policy
+}
+
+resource "aws_ecr_lifecycle_policy" "api_nginx" {
+  repository = aws_ecr_repository.api_nginx.name
+  policy     = local.lifecycle_policy
+}

--- a/modules/aws/ecs/ecs.tf
+++ b/modules/aws/ecs/ecs.tf
@@ -1,0 +1,65 @@
+resource "aws_ecs_cluster" "api" {
+  name = var.name
+
+  setting {
+    name  = "containerInsights"
+    value = var.enable_container_insights ? "enabled" : "disabled"
+  }
+}
+
+resource "aws_ecs_task_definition" "api" {
+  family       = var.name
+  network_mode = "awsvpc"
+  container_definitions = templatefile("${path.module}/task/task.json", {
+    app_image_url             = aws_ecr_repository.api_app.repository_url
+    app_aws_logs_group        = aws_cloudwatch_log_group.api_app_log.name
+    nginx_image_url           = aws_ecr_repository.api_nginx.repository_url
+    nginx_aws_logs_group      = aws_cloudwatch_log_group.api_nginx_log.name
+    aws_region                = data.aws_region.current.name
+    db_hostname_arn           = aws_ssm_parameter.db_hostname.arn
+    db_password_arn           = aws_ssm_parameter.db_password.arn
+    db_username_arn           = aws_ssm_parameter.db_username.arn
+    db_name_arn               = aws_ssm_parameter.db_name.arn
+    upload_images_bucket_name = var.upload_images_bucket_name
+    lgtm_images_cdn_domain    = var.lgtm_images_cdn_domain
+  })
+
+  cpu                      = var.ecs_task_cpu
+  memory                   = var.ecs_task_memory
+  requires_compatibilities = ["FARGATE"]
+  execution_role_arn       = aws_iam_role.ecs_task_execution_role.arn
+  task_role_arn            = aws_iam_role.ecs_task.arn
+
+  depends_on = [aws_cloudwatch_log_group.api_app_log]
+}
+
+resource "aws_ecs_service" "bff_service" {
+  name             = var.name
+  cluster          = aws_ecs_cluster.api.id
+  task_definition  = aws_ecs_task_definition.api.arn
+  desired_count    = var.ecs_service_desired_count
+  launch_type      = "FARGATE"
+  platform_version = "1.4.0"
+
+  load_balancer {
+    target_group_arn = aws_alb_target_group.api_public.id
+    container_name   = "nginx"
+    container_port   = 80
+  }
+
+  network_configuration {
+    subnets = var.subnet_public_ids
+
+    security_groups = [
+      aws_security_group.api_ecs.id,
+    ]
+  }
+
+  lifecycle {
+    ignore_changes = [
+      task_definition,
+    ]
+  }
+
+  depends_on = [aws_alb_listener.api_public]
+}

--- a/modules/aws/ecs/ecs.tf
+++ b/modules/aws/ecs/ecs.tf
@@ -33,7 +33,7 @@ resource "aws_ecs_task_definition" "api" {
   depends_on = [aws_cloudwatch_log_group.api_app_log]
 }
 
-resource "aws_ecs_service" "bff_service" {
+resource "aws_ecs_service" "api" {
   name             = var.name
   cluster          = aws_ecs_cluster.api.id
   task_definition  = aws_ecs_task_definition.api.arn

--- a/modules/aws/ecs/iam.tf
+++ b/modules/aws/ecs/iam.tf
@@ -1,0 +1,71 @@
+data "aws_iam_policy_document" "ecs_task_execution_role" {
+  statement {
+    effect = "Allow"
+
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "ecs_task_execution_role" {
+  name               = "${var.name}-ecs-task-execution-role"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_execution_role.json
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_attach" {
+  role       = aws_iam_role.ecs_task_execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+data "aws_iam_policy_document" "ssm_for_ecs_task_execution_role" {
+  statement {
+    effect    = "Allow"
+    actions   = ["ssm:GetParameters"]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "ssm_for_ecs_task_execution_role" {
+  name   = "${var.env}-ssm-for-ecs-task-execution-role"
+  role   = aws_iam_role.ecs_task_execution_role.id
+  policy = data.aws_iam_policy_document.ssm_for_ecs_task_execution_role.json
+}
+
+data "aws_iam_policy_document" "ecs_task_role" {
+  statement {
+    effect = "Allow"
+
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "ecs_task" {
+  name               = "${var.name}-ecs-task-role"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_role.json
+}
+
+data "aws_iam_policy_document" "task_role_policy" {
+  statement {
+    effect  = "Allow"
+    actions = ["s3:*", ]
+    resources = [
+      "arn:aws:s3:::${var.upload_images_bucket_name}",
+      "arn:aws:s3:::${var.upload_images_bucket_name}/*"
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "ecs_task" {
+  name   = "${var.name}-ecs-task-role-policy"
+  role   = aws_iam_role.ecs_task.id
+  policy = data.aws_iam_policy_document.task_role_policy.json
+}

--- a/modules/aws/ecs/outputs.tf
+++ b/modules/aws/ecs/outputs.tf
@@ -1,0 +1,3 @@
+output "ecs_securitygroup_id" {
+  value = aws_security_group.api_ecs.id
+}

--- a/modules/aws/ecs/route53.tf
+++ b/modules/aws/ecs/route53.tf
@@ -1,0 +1,11 @@
+resource "aws_route53_record" "api_public" {
+  name    = var.ecs_domain_name
+  type    = "A"
+  zone_id = var.zone_id
+
+  alias {
+    evaluate_target_health = false
+    name                   = aws_alb.api_public.dns_name
+    zone_id                = aws_alb.api_public.zone_id
+  }
+}

--- a/modules/aws/ecs/security-group.tf
+++ b/modules/aws/ecs/security-group.tf
@@ -1,0 +1,48 @@
+resource "aws_security_group" "api_public_alb" {
+  name        = "${var.name}-alb"
+  description = "${var.name}-alb"
+  vpc_id      = var.vpc_id
+}
+
+resource "aws_security_group_rule" "api_public_alb_ingress" {
+  security_group_id = aws_security_group.api_public_alb.id
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "api_public_alb_egress" {
+  security_group_id = aws_security_group.api_public_alb.id
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group" "api_ecs" {
+  name   = "${var.name}-ecs"
+  vpc_id = var.vpc_id
+}
+
+resource "aws_security_group_rule" "api_ecs_egress" {
+  security_group_id = aws_security_group.api_ecs.id
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+
+resource "aws_security_group_rule" "bff_ecs_from_alb" {
+  security_group_id        = aws_security_group.api_ecs.id
+  type                     = "ingress"
+  from_port                = "80"
+  to_port                  = "80"
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.api_public_alb.id
+}
+

--- a/modules/aws/ecs/security-group.tf
+++ b/modules/aws/ecs/security-group.tf
@@ -37,7 +37,7 @@ resource "aws_security_group_rule" "api_ecs_egress" {
 }
 
 
-resource "aws_security_group_rule" "bff_ecs_from_alb" {
+resource "aws_security_group_rule" "api_ecs_from_alb" {
   security_group_id        = aws_security_group.api_ecs.id
   type                     = "ingress"
   from_port                = "80"

--- a/modules/aws/ecs/ssm.tf
+++ b/modules/aws/ecs/ssm.tf
@@ -1,0 +1,27 @@
+resource "aws_ssm_parameter" "db_hostname" {
+  name      = "/${var.env}/lgtm-cat/api/DB_HOSTNAME"
+  type      = "SecureString"
+  value     = var.db_hostname
+  overwrite = true
+}
+
+resource "aws_ssm_parameter" "db_username" {
+  name      = "/${var.env}/lgtm-cat/api/DB_USERNAME"
+  type      = "SecureString"
+  value     = var.db_username
+  overwrite = true
+}
+
+resource "aws_ssm_parameter" "db_name" {
+  name      = "/${var.env}/lgtm-cat/api/DB_NAME"
+  type      = "SecureString"
+  value     = var.db_name
+  overwrite = true
+}
+
+resource "aws_ssm_parameter" "db_password" {
+  name      = "/${var.env}/lgtm-cat/api/DB_PASSWORD"
+  type      = "SecureString"
+  value     = var.db_password
+  overwrite = true
+}

--- a/modules/aws/ecs/task/task.json
+++ b/modules/aws/ecs/task/task.json
@@ -1,0 +1,91 @@
+[
+  {
+    "name": "app",
+    "image": "${app_image_url}",
+    "essential": true,
+    "ulimits": [
+      {
+        "name": "nofile",
+        "softLimit": 1024000,
+        "hardLimit": 1024000
+      }
+    ],
+    "secrets": [
+      {
+        "name": "DB_HOSTNAME",
+        "valueFrom": "${db_hostname_arn}"
+      },
+      {
+        "name": "DB_PASSWORD",
+        "valueFrom": "${db_password_arn}"
+      },
+      {
+        "name": "DB_USERNAME",
+        "valueFrom": "${db_username_arn}"
+      },
+      {
+        "name": "DB_NAME",
+        "valueFrom": "${db_name_arn}"
+      }
+     ],
+      "environment": [
+      {
+        "name": "REGION",
+        "value": "${aws_region}"
+      },
+      {
+        "name": "UPLOAD_S3_BUCKET_NAME",
+        "value": "${upload_images_bucket_name}"
+      },
+      {
+        "name": "LGTM_IMAGES_CDN_DOMAIN",
+        "value": "${lgtm_images_cdn_domain}"
+      }
+    ],
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "${app_aws_logs_group}",
+        "awslogs-region": "${aws_region}",
+        "awslogs-stream-prefix": "ecs"
+      }
+    }
+  },
+  {
+    "name": "nginx",
+    "image": "${nginx_image_url}",
+    "essential": true,
+    "ulimits": [
+      {
+        "name": "nofile",
+        "softLimit": 1024000,
+        "hardLimit": 1024000
+      }
+    ],
+    "portMappings": [
+      {
+        "containerPort": 80,
+        "hostPort": 80,
+        "protocol": "tcp"
+      }
+    ],
+    "environment": [
+      {
+        "name": "BACKEND_HOST",
+        "value": "127.0.0.1"
+      },
+      {
+        "name": "PORT",
+        "value": "80"
+      }
+    ],
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "${nginx_aws_logs_group}",
+        "awslogs-region": "${aws_region}",
+        "awslogs-stream-prefix": "ecs"
+      }
+    }
+  }
+]

--- a/modules/aws/ecs/variables.tf
+++ b/modules/aws/ecs/variables.tf
@@ -1,0 +1,56 @@
+variable "env" {
+  type = string
+}
+variable "vpc_id" {
+  type = string
+}
+variable "subnet_public_ids" {
+  type = list(string)
+}
+variable "certificate_arn" {
+  type = string
+}
+variable "ecs_domain_name" {
+  type = string
+}
+variable "zone_id" {
+  type = string
+}
+variable "name" {
+  type = string
+}
+variable "enable_container_insights" {
+  type = bool
+}
+variable "log_retention_in_days" {
+  type = number
+}
+variable "ecs_service_desired_count" {
+  type = number
+}
+variable "ecs_task_cpu" {
+  type = number
+}
+variable "ecs_task_memory" {
+  type = number
+}
+variable "upload_images_bucket_name" {
+  type = string
+}
+variable "db_hostname" {
+  type = string
+}
+variable "db_password" {
+  type = string
+}
+variable "db_username" {
+  type = string
+}
+variable "db_name" {
+  type = string
+}
+variable "lgtm_images_cdn_domain" {
+  type = string
+}
+
+data "aws_region" "current" {}

--- a/modules/aws/rds/proxy.tf
+++ b/modules/aws/rds/proxy.tf
@@ -121,3 +121,12 @@ resource "aws_security_group_rule" "rds_from_stg_api_lambda" {
   protocol                 = "tcp"
   source_security_group_id = var.stg_api_lambda_securitygroup_id
 }
+
+resource "aws_security_group_rule" "rds_from_stg_api_ecs" {
+  security_group_id        = aws_security_group.rds_proxy_stg.id
+  type                     = "ingress"
+  from_port                = "3306"
+  to_port                  = "3306"
+  protocol                 = "tcp"
+  source_security_group_id = var.stg_api_ecs_securitygroup_id
+}

--- a/modules/aws/rds/variables.tf
+++ b/modules/aws/rds/variables.tf
@@ -78,6 +78,10 @@ variable "stg_api_lambda_securitygroup_id" {
   type = string
 }
 
+variable "stg_api_ecs_securitygroup_id" {
+  type = string
+}
+
 variable "migration_ecs_securitygroup_id" {
   type = string
 }

--- a/modules/aws/vpc/main.tf
+++ b/modules/aws/vpc/main.tf
@@ -63,3 +63,38 @@ resource "aws_vpc_endpoint_route_table_association" "example" {
   vpc_endpoint_id = aws_vpc_endpoint.s3.id
   route_table_id  = aws_route_table.public.id
 }
+
+resource "aws_vpc_endpoint" "ecr_api" {
+  vpc_id              = aws_vpc.this.id
+  service_name        = "com.amazonaws.ap-northeast-1.ecr.api"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = aws_subnet.public[*].id
+  security_group_ids  = [aws_security_group.vpc_endpoint.id]
+  private_dns_enabled = true
+}
+
+resource "aws_vpc_endpoint" "ecr_dkr" {
+  vpc_id              = aws_vpc.this.id
+  service_name        = "com.amazonaws.ap-northeast-1.ecr.dkr"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = aws_subnet.public[*].id
+  security_group_ids  = [aws_security_group.vpc_endpoint.id]
+  private_dns_enabled = true
+}
+resource "aws_vpc_endpoint" "ssm" {
+  vpc_id              = aws_vpc.this.id
+  service_name        = "com.amazonaws.ap-northeast-1.ssm"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = aws_subnet.public[*].id
+  security_group_ids  = [aws_security_group.vpc_endpoint.id]
+  private_dns_enabled = true
+}
+
+resource "aws_vpc_endpoint" "logs" {
+  vpc_id              = aws_vpc.this.id
+  service_name        = "com.amazonaws.ap-northeast-1.logs"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = aws_subnet.public[*].id
+  security_group_ids  = [aws_security_group.vpc_endpoint.id]
+  private_dns_enabled = true
+}

--- a/modules/aws/vpc/security-group.tf
+++ b/modules/aws/vpc/security-group.tf
@@ -1,0 +1,22 @@
+resource "aws_security_group" "vpc_endpoint" {
+  name   = "vpc-endpoint"
+  vpc_id = aws_vpc.this.id
+}
+
+resource "aws_security_group_rule" "vpc_endpoint_egress" {
+  type              = "egress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = [aws_vpc.this.cidr_block]
+  security_group_id = aws_security_group.vpc_endpoint.id
+}
+
+resource "aws_security_group_rule" "vpc_endpoint_ingress" {
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = [aws_vpc.this.cidr_block]
+  security_group_id = aws_security_group.vpc_endpoint.id
+}

--- a/modules/aws/vpc/security-group.tf
+++ b/modules/aws/vpc/security-group.tf
@@ -3,15 +3,6 @@ resource "aws_security_group" "vpc_endpoint" {
   vpc_id = aws_vpc.this.id
 }
 
-resource "aws_security_group_rule" "vpc_endpoint_egress" {
-  type              = "egress"
-  from_port         = 443
-  to_port           = 443
-  protocol          = "tcp"
-  cidr_blocks       = [aws_vpc.this.cidr_block]
-  security_group_id = aws_security_group.vpc_endpoint.id
-}
-
 resource "aws_security_group_rule" "vpc_endpoint_ingress" {
   type              = "ingress"
   from_port         = 443

--- a/providers/aws/environments/prod/23-rds/main.tf
+++ b/providers/aws/environments/prod/23-rds/main.tf
@@ -29,4 +29,5 @@ module "rds" {
   stg_migration_ecs_securitygroup_id = data.terraform_remote_state.stg_migration.outputs.migration_ecs_securitygroup_id
   stg_lambda_securitygroup_id        = data.terraform_remote_state.stg_lambda_securitygroup.outputs.lambda_security_group_id
   stg_api_lambda_securitygroup_id    = data.terraform_remote_state.stg_api.outputs.api_lambda_securitygroup_id
+  stg_api_ecs_securitygroup_id    = data.terraform_remote_state.stg_api.outputs.api_ecs_securitygroup_id
 }

--- a/providers/aws/environments/prod/23-rds/main.tf
+++ b/providers/aws/environments/prod/23-rds/main.tf
@@ -29,5 +29,5 @@ module "rds" {
   stg_migration_ecs_securitygroup_id = data.terraform_remote_state.stg_migration.outputs.migration_ecs_securitygroup_id
   stg_lambda_securitygroup_id        = data.terraform_remote_state.stg_lambda_securitygroup.outputs.lambda_security_group_id
   stg_api_lambda_securitygroup_id    = data.terraform_remote_state.stg_api.outputs.api_lambda_securitygroup_id
-  stg_api_ecs_securitygroup_id    = data.terraform_remote_state.stg_api.outputs.api_ecs_securitygroup_id
+  stg_api_ecs_securitygroup_id       = data.terraform_remote_state.stg_api.outputs.api_ecs_securitygroup_id
 }

--- a/providers/aws/environments/stg/20-api/main.tf
+++ b/providers/aws/environments/stg/20-api/main.tf
@@ -34,3 +34,26 @@ module "api_gateway" {
   image_recognition_api_gateway_domain_name = local.image_recognition_api_gateway_domain_name
   depends_on                                = [module.lambda]
 }
+
+module "ecs" {
+  source = "../../../../../modules/aws/ecs"
+
+  env                       = local.env
+  vpc_id                    = data.terraform_remote_state.network.outputs.vpc_id
+  subnet_public_ids         = data.terraform_remote_state.network.outputs.subnet_public_ids
+  certificate_arn           = data.terraform_remote_state.acm.outputs.ap_northeast_1_sub_domain_acm_arn
+  ecs_domain_name           = local.ecs_domain_name
+  zone_id                   = data.aws_route53_zone.api.zone_id
+  name                      = local.name
+  enable_container_insights = local.enable_container_insights
+  log_retention_in_days     = local.log_retention_in_days
+  ecs_service_desired_count = local.ecs_service_desired_count
+  ecs_task_cpu              = local.ecs_task_cpu
+  ecs_task_memory           = local.ecs_task_memory
+  upload_images_bucket_name = data.terraform_remote_state.images.outputs.upload_images_bucket_name
+  db_hostname               = local.db_hostname
+  db_name                   = local.db_name
+  db_password               = local.db_password
+  db_username               = local.db_username
+  lgtm_images_cdn_domain    = data.terraform_remote_state.images.outputs.lgtm_images_cdn_domain
+}

--- a/providers/aws/environments/stg/20-api/outputs.tf
+++ b/providers/aws/environments/stg/20-api/outputs.tf
@@ -1,3 +1,7 @@
 output "api_lambda_securitygroup_id" {
   value = module.lambda.lambda_securitygroup_id
 }
+
+output "api_ecs_securitygroup_id" {
+  value = module.ecs.ecs_securitygroup_id
+}

--- a/providers/aws/environments/stg/20-api/variables.tf
+++ b/providers/aws/environments/stg/20-api/variables.tf
@@ -23,6 +23,16 @@ locals {
   db_hostname = "lgtm-cat-rds-proxy.${local.env}"
 }
 
+
+locals {
+  name                      = "${local.env}-lgtm-cat-api"
+  ecs_domain_name           = "${local.env}-ecs-api.${var.main_domain_name}"
+  enable_container_insights = false
+  ecs_service_desired_count = 1
+  ecs_task_cpu              = 256
+  ecs_task_memory           = 512
+}
+
 variable "main_domain_name" {
   type    = string
   default = "lgtmeow.com"


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-terraform/issues/77

# Doneの定義
https://github.com/nekochans/lgtm-cat-terraform/issues/77 の完了条件を満たしていること

# 変更点概要
大きく以下の3つの変更を行った。
STGの設定のみ追加し、本番用の設定は別のPRで対応予定。

* [lgtm-cat-api 用の ECS を追加](https://github.com/nekochans/lgtm-cat-terraform/commit/67c68c75f0c2e5843c27a87083e4ce877b0e82ea)
  * private sub は構築していないので、public subnet に ECS Fargateを構築
  * デプロイタイプはローリングアップデート
  * ALB のセキュリティポリシーは `ELBSecurityPolicy-TLS-1-2-Ext-2018-06` を指定し、非推奨である TLS 1.0、1.1 は無効とした

* [STG lgtm-cat-api ECS から RDS に接続できるようにセキュリティグループのルールを追加](https://github.com/nekochans/lgtm-cat-terraform/commit/a35c50f24853863eab32faee4a2fee6ffd8bdb14)

* [ECS に必要となる VPC エンドポイントを追加](https://github.com/nekochans/lgtm-cat-terraform/commit/890b7e5a677804177cbdef6e1d558f813d0a50bb)
  * NAT Gateway が存在しないため必要となる 
  * 以下の4つについて追加
    * CloudWatch Logs
    * パラメータストア
    * ECR (`com.amazonaws.region.ecr.dkr`)
    * ECR (`com.amazonaws.region.ecr.api`)
  * インタフェースエンドポイントのため料金が発生する

# 補足情報
アプリケーション の変更は lgtm-cat-api https://github.com/nekochans/lgtm-cat-api/pull/75 で対応。
