### PR TITLE
lgtm-cat-api の Sentry 導入に必要となる環境変数を ECS に追加

### DIFF
--- a/modules/aws/ecs/ecs.tf
+++ b/modules/aws/ecs/ecs.tf
@@ -11,6 +11,7 @@ resource "aws_ecs_task_definition" "api" {
   family       = var.name
   network_mode = "awsvpc"
   container_definitions = templatefile("${path.module}/task/task.json", {
+    env                       = var.env
     app_image_url             = aws_ecr_repository.api_app.repository_url
     app_aws_logs_group        = aws_cloudwatch_log_group.api_app_log.name
     nginx_image_url           = aws_ecr_repository.api_nginx.repository_url
@@ -19,6 +20,7 @@ resource "aws_ecs_task_definition" "api" {
     db_hostname_arn           = aws_ssm_parameter.db_hostname.arn
     db_password_arn           = aws_ssm_parameter.db_password.arn
     db_username_arn           = aws_ssm_parameter.db_username.arn
+    sentry_dsn_arn            = aws_ssm_parameter.sentry_dsn.arn
     db_name_arn               = aws_ssm_parameter.db_name.arn
     upload_images_bucket_name = var.upload_images_bucket_name
     lgtm_images_cdn_domain    = var.lgtm_images_cdn_domain

--- a/modules/aws/ecs/ecs.tf
+++ b/modules/aws/ecs/ecs.tf
@@ -50,7 +50,8 @@ resource "aws_ecs_service" "api" {
   }
 
   network_configuration {
-    subnets = var.subnet_public_ids
+    subnets          = var.subnet_public_ids
+    assign_public_ip = true
 
     security_groups = [
       aws_security_group.api_ecs.id,

--- a/modules/aws/ecs/ssm.tf
+++ b/modules/aws/ecs/ssm.tf
@@ -25,3 +25,10 @@ resource "aws_ssm_parameter" "db_password" {
   value     = var.db_password
   overwrite = true
 }
+
+resource "aws_ssm_parameter" "sentry_dsn" {
+  name      = "/${var.env}/lgtm-cat/api/SENTRY_DSN"
+  type      = "SecureString"
+  value     = var.sentry_dsn
+  overwrite = true
+}

--- a/modules/aws/ecs/task/task.json
+++ b/modules/aws/ecs/task/task.json
@@ -26,9 +26,17 @@
       {
         "name": "DB_NAME",
         "valueFrom": "${db_name_arn}"
+      },
+      {
+        "name": "SENTRY_DSN",
+        "valueFrom": "${sentry_dsn_arn}"
       }
      ],
       "environment": [
+      {
+          "name": "ENV",
+          "value": "${env}"
+      },
       {
         "name": "REGION",
         "value": "${aws_region}"

--- a/modules/aws/ecs/variables.tf
+++ b/modules/aws/ecs/variables.tf
@@ -52,5 +52,8 @@ variable "db_name" {
 variable "lgtm_images_cdn_domain" {
   type = string
 }
+variable "sentry_dsn" {
+  type = string
+}
 
 data "aws_region" "current" {}

--- a/providers/aws/environments/stg/20-api/main.tf
+++ b/providers/aws/environments/stg/20-api/main.tf
@@ -56,4 +56,5 @@ module "ecs" {
   db_password               = local.db_password
   db_username               = local.db_username
   lgtm_images_cdn_domain    = data.terraform_remote_state.images.outputs.lgtm_images_cdn_domain
+  sentry_dsn                = local.sentry_dsn
 }

--- a/providers/aws/environments/stg/20-api/variables.tf
+++ b/providers/aws/environments/stg/20-api/variables.tf
@@ -31,6 +31,7 @@ locals {
   ecs_service_desired_count = 1
   ecs_task_cpu              = 256
   ecs_task_memory           = 512
+  sentry_dsn                = jsondecode(data.aws_secretsmanager_secret_version.secret.secret_string)["sentry_dsn"]
 }
 
 variable "main_domain_name" {


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-api/issues/77

# Doneの定義
https://github.com/nekochans/lgtm-cat-api/issues/77 の対応に必要となる環境変数が ECS に追加されていること

# 変更点概要
* lgtm-cat-api の Sentry 導入に必要となる環境変数を ECS に追加。
  * `SENTRY_DSN`の値は SecretManager に追加済み。

* パブリックサブネットの ECS から外部のネットワークに接続するためにパブリック IP アドレスの割り当てを有効化
  * Sentry にエラーを送信するために必要となる
  * ECS のセキュリティグループにより ALB からのみリクエストを許可する設定としているため、直接 パブリック IP にリクエストすることはできない

# 補足情報
アプリケーションは https://github.com/nekochans/lgtm-cat-api/pull/78 で対応。
