### PR TITLE
本番環境 lgtm-cat-api 用の ECS を構築

### DIFF
--- a/modules/aws/rds/proxy.tf
+++ b/modules/aws/rds/proxy.tf
@@ -85,6 +85,15 @@ resource "aws_security_group_rule" "rds_from_api_lambda" {
   source_security_group_id = var.api_lambda_securitygroup_id
 }
 
+resource "aws_security_group_rule" "rds_from_api_ecs" {
+  security_group_id        = aws_security_group.rds_proxy.id
+  type                     = "ingress"
+  from_port                = "3306"
+  to_port                  = "3306"
+  protocol                 = "tcp"
+  source_security_group_id = var.api_ecs_securitygroup_id
+}
+
 resource "aws_security_group" "rds_proxy_stg" {
   name        = "stg-${var.rds_name}-rds-proxy"
   description = "${var.rds_name} RDS Proxy Security Group for stg"

--- a/modules/aws/rds/variables.tf
+++ b/modules/aws/rds/variables.tf
@@ -70,6 +70,11 @@ variable "api_lambda_securitygroup_id" {
   type = string
 }
 
+variable "api_ecs_securitygroup_id" {
+  type = string
+}
+
+
 variable "stg_lambda_securitygroup_id" {
   type = string
 }

--- a/providers/aws/environments/prod/20-api/main.tf
+++ b/providers/aws/environments/prod/20-api/main.tf
@@ -34,3 +34,27 @@ module "api_gateway" {
   image_recognition_api_gateway_domain_name = local.image_recognition_api_gateway_domain_name
   depends_on                                = [module.lambda]
 }
+
+module "ecs" {
+  source = "../../../../../modules/aws/ecs"
+
+  env                       = local.env
+  vpc_id                    = data.terraform_remote_state.network.outputs.vpc_id
+  subnet_public_ids         = data.terraform_remote_state.network.outputs.subnet_public_ids
+  certificate_arn           = data.terraform_remote_state.acm.outputs.ap_northeast_1_sub_domain_acm_arn
+  ecs_domain_name           = local.ecs_domain_name
+  zone_id                   = data.aws_route53_zone.api.zone_id
+  name                      = local.name
+  enable_container_insights = local.enable_container_insights
+  log_retention_in_days     = local.log_retention_in_days
+  ecs_service_desired_count = local.ecs_service_desired_count
+  ecs_task_cpu              = local.ecs_task_cpu
+  ecs_task_memory           = local.ecs_task_memory
+  upload_images_bucket_name = data.terraform_remote_state.images.outputs.upload_images_bucket_name
+  db_hostname               = local.db_hostname
+  db_name                   = local.db_name
+  db_password               = local.db_password
+  db_username               = local.db_username
+  lgtm_images_cdn_domain    = data.terraform_remote_state.images.outputs.lgtm_images_cdn_domain
+  sentry_dsn                = local.sentry_dsn
+}

--- a/providers/aws/environments/prod/20-api/outputs.tf
+++ b/providers/aws/environments/prod/20-api/outputs.tf
@@ -1,3 +1,7 @@
 output "api_lambda_securitygroup_id" {
   value = module.lambda.lambda_securitygroup_id
 }
+
+output "api_ecs_securitygroup_id" {
+  value = module.ecs.ecs_securitygroup_id
+}

--- a/providers/aws/environments/prod/20-api/variables.tf
+++ b/providers/aws/environments/prod/20-api/variables.tf
@@ -23,6 +23,16 @@ locals {
   db_hostname = "lgtm-cat-rds-proxy.${local.env}"
 }
 
+locals {
+  name                      = "${local.env}-lgtm-cat-api"
+  ecs_domain_name           = "ecs-api.${var.main_domain_name}"
+  enable_container_insights = false
+  ecs_service_desired_count = 1
+  ecs_task_cpu              = 256
+  ecs_task_memory           = 512
+  sentry_dsn                = jsondecode(data.aws_secretsmanager_secret_version.secret.secret_string)["sentry_dsn"]
+}
+
 variable "main_domain_name" {
   type    = string
   default = "lgtmeow.com"

--- a/providers/aws/environments/prod/23-rds/main.tf
+++ b/providers/aws/environments/prod/23-rds/main.tf
@@ -22,6 +22,7 @@ module "rds" {
   migration_ecs_securitygroup_id = data.terraform_remote_state.migration.outputs.migration_ecs_securitygroup_id
   lambda_securitygroup_id        = data.terraform_remote_state.lambda_securitygroup.outputs.lambda_security_group_id
   api_lambda_securitygroup_id    = data.terraform_remote_state.api.outputs.api_lambda_securitygroup_id
+  api_ecs_securitygroup_id       = data.terraform_remote_state.api.outputs.api_ecs_securitygroup_id
 
   // STG用
   stg_app_password                   = local.stg_app_password


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-terraform/issues/77

# 関連URL
STG環境 PR
https://github.com/nekochans/lgtm-cat-terraform/pull/80

# Doneの定義
本番環境用 lgtm-cat-api 用の ECS を構築 が構築されていること

# 変更点概要
https://github.com/nekochans/lgtm-cat-terraform/pull/80 の横展開。本番環境 ECS を構築。

# 補足情報
https://github.com/nekochans/lgtm-cat-api/issues/76 の対応が完了するまでは移行できないので、Lambda環境は残したままとしている。