### PR TITLE
lgtm-cat-api ECS にアクセストークンの検証に必要となる環境変数を追加

### DIFF
--- a/modules/aws/cognito/outputs.tf
+++ b/modules/aws/cognito/outputs.tf
@@ -5,3 +5,7 @@ output "idp_endpoint" {
 output "lgtm_cat_bff_client_id" {
   value = aws_cognito_user_pool_client.lgtm_cat_bff_client.id
 }
+
+output "cognito_user_pool_id" {
+  value = aws_cognito_user_pool.user_pool.id
+}

--- a/modules/aws/ecs/ecs.tf
+++ b/modules/aws/ecs/ecs.tf
@@ -24,6 +24,7 @@ resource "aws_ecs_task_definition" "api" {
     db_name_arn               = aws_ssm_parameter.db_name.arn
     upload_images_bucket_name = var.upload_images_bucket_name
     lgtm_images_cdn_domain    = var.lgtm_images_cdn_domain
+    cognito_user_pool_id      = var.cognito_user_pool_id
   })
 
   cpu                      = var.ecs_task_cpu

--- a/modules/aws/ecs/task/task.json
+++ b/modules/aws/ecs/task/task.json
@@ -48,6 +48,10 @@
       {
         "name": "LGTM_IMAGES_CDN_DOMAIN",
         "value": "${lgtm_images_cdn_domain}"
+      },
+      {
+        "name": "COGNITO_USER_POOL_ID",
+        "value": "${cognito_user_pool_id}"
       }
     ],
     "logConfiguration": {

--- a/modules/aws/ecs/variables.tf
+++ b/modules/aws/ecs/variables.tf
@@ -55,5 +55,8 @@ variable "lgtm_images_cdn_domain" {
 variable "sentry_dsn" {
   type = string
 }
+variable "cognito_user_pool_id" {
+  type = string
+}
 
 data "aws_region" "current" {}

--- a/providers/aws/environments/prod/17-cognito/outputs.tf
+++ b/providers/aws/environments/prod/17-cognito/outputs.tf
@@ -7,3 +7,8 @@ output "lgtm_cat_bff_client_id" {
   value     = module.cognito.lgtm_cat_bff_client_id
   sensitive = true
 }
+
+output "cognito_user_pool_id" {
+  value     = module.cognito.cognito_user_pool_id
+  sensitive = true
+}

--- a/providers/aws/environments/prod/20-api/main.tf
+++ b/providers/aws/environments/prod/20-api/main.tf
@@ -57,4 +57,5 @@ module "ecs" {
   db_username               = local.db_username
   lgtm_images_cdn_domain    = data.terraform_remote_state.images.outputs.lgtm_images_cdn_domain
   sentry_dsn                = local.sentry_dsn
+  cognito_user_pool_id      = data.terraform_remote_state.cognito.outputs.cognito_user_pool_id
 }

--- a/providers/aws/environments/stg/17-cognito/outputs.tf
+++ b/providers/aws/environments/stg/17-cognito/outputs.tf
@@ -7,3 +7,8 @@ output "lgtm_cat_bff_client_id" {
   value     = module.cognito.lgtm_cat_bff_client_id
   sensitive = true
 }
+
+output "cognito_user_pool_id" {
+  value     = module.cognito.cognito_user_pool_id
+  sensitive = true
+}

--- a/providers/aws/environments/stg/20-api/main.tf
+++ b/providers/aws/environments/stg/20-api/main.tf
@@ -57,4 +57,5 @@ module "ecs" {
   db_username               = local.db_username
   lgtm_images_cdn_domain    = data.terraform_remote_state.images.outputs.lgtm_images_cdn_domain
   sentry_dsn                = local.sentry_dsn
+  cognito_user_pool_id      = data.terraform_remote_state.cognito.outputs.cognito_user_pool_id
 }


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-api/issues/76

# Doneの定義
lgtm-cat-api ECS にアクセストークンの検証に必要となる環境変数が追加されていること

# 変更点概要
lgtm-cat-api ECS の環境変数に Cognito User Pool ID を追加。

# 補足情報
アプリケーションは https://github.com/nekochans/lgtm-cat-api/pull/79 で対応。
