### PR TITLE
set-output コマンド廃止の対応のために hashicorp/setup-terraform を v2 に変更

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v1
+      uses: hashicorp/setup-terraform@v2
       with:
         terraform_version: 1.0.3
 


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-terraform/issues/92

# Doneの定義
https://github.com/nekochans/lgtm-cat-terraform/issues/92 の完了条件を満たしていること

# 変更点概要
`set-output`コマンドを利用していた hashicorp/setup-terraform@v1 を v2 に変更。

warning が表示されないことを確認済み。
https://github.com/nekochans/lgtm-cat-terraform/actions/runs/4330362285