### PR TITLE
Node.12 deprecated 対応のために actions/checkout@v3 に変更

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         shell: bash
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
 
 jobs:
   terraform:


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-terraform/issues/91

# Doneの定義
https://github.com/nekochans/lgtm-cat-terraform/issues/91 の完了条件を満たしていること

# 変更点概要
Node.12 deprecated 対応のために actions/checkout@v3 に変更

warning が表示されることを確認済み。
https://github.com/nekochans/lgtm-cat-terraform/actions/runs/4330403042

また、Issue とは関係ないが以下の変更も行った。
[main 以外に対する PR 作成時も CI が実行されるように変更](https://github.com/nekochans/lgtm-cat-terraform/pull/94/commits/7bf3392ff8946352a66d3e09964301f41307b002)