### PR TITLE
STG の ECS を1日1回停止する EventBridge Scheduler を構築

### DIFF
--- a/modules/aws/ecs-stop-scheduler/eventbridge-scheduler.tf
+++ b/modules/aws/ecs-stop-scheduler/eventbridge-scheduler.tf
@@ -7,7 +7,7 @@ resource "aws_scheduler_schedule_group" "stop_ecs" {
 resource "aws_scheduler_schedule" "stop_ecs" {
   for_each = { for i in var.ecs_targets : i.cluster => i }
 
-  name       = "${var.env}-stop-ecs"
+  name       = "${var.env}-stop-ecs-${each.value.service}"
   group_name = aws_scheduler_schedule_group.stop_ecs[0].name
   state      = "ENABLED"
 

--- a/modules/aws/ecs-stop-scheduler/eventbridge-scheduler.tf
+++ b/modules/aws/ecs-stop-scheduler/eventbridge-scheduler.tf
@@ -1,0 +1,37 @@
+resource "aws_scheduler_schedule_group" "stop_ecs" {
+  count = var.env != "prod" ? 1 : 0
+
+  name = "${var.env}-stop-ecs-group"
+}
+
+resource "aws_scheduler_schedule" "stop_ecs" {
+  for_each = { for i in var.ecs_targets : i.cluster => i }
+
+  name       = "${var.env}-stop-ecs"
+  group_name = aws_scheduler_schedule_group.stop_ecs[0].name
+  state      = "ENABLED"
+
+  schedule_expression_timezone = "Asia/Tokyo"
+  schedule_expression          = "cron(0 3 * * ? *)"
+
+  flexible_time_window {
+    mode                      = "FLEXIBLE"
+    maximum_window_in_minutes = 10
+  }
+
+  target {
+    arn      = "arn:aws:scheduler:::aws-sdk:ecs:updateService"
+    role_arn = aws_iam_role.ecs_stop_scheduler[0].arn
+
+    input = jsonencode({
+      "Cluster" : each.value.cluster,
+      "Service" : each.value.service,
+      "DesiredCount" : 0
+    })
+
+    retry_policy {
+      maximum_event_age_in_seconds = 3600
+      maximum_retry_attempts       = 3
+    }
+  }
+}

--- a/modules/aws/ecs-stop-scheduler/iam.tf
+++ b/modules/aws/ecs-stop-scheduler/iam.tf
@@ -1,0 +1,34 @@
+data "aws_iam_policy_document" "assume_role_policy" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["scheduler.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "ecs_stop_scheduler" {
+  count = var.env != "prod" ? 1 : 0
+
+  name               = "${var.env}-ecs-stop-scheduler-role"
+  assume_role_policy = data.aws_iam_policy_document.assume_role_policy.json
+}
+
+
+data "aws_iam_policy_document" "ecs_stop_scheduler" {
+  statement {
+    effect    = "Allow"
+    actions   = ["ecs:UpdateService"]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "ecs_stop_scheduler" {
+  count = var.env != "prod" ? 1 : 0
+
+  name   = "${var.env}-ecs-stop-scheduler-role-policy"
+  role   = aws_iam_role.ecs_stop_scheduler[count.index].id
+  policy = data.aws_iam_policy_document.ecs_stop_scheduler.json
+}

--- a/modules/aws/ecs-stop-scheduler/variables.tf
+++ b/modules/aws/ecs-stop-scheduler/variables.tf
@@ -1,0 +1,7 @@
+variable "env" {
+  type = string
+}
+
+variable "ecs_targets" {
+  type = list(object({ cluster : string, service : string }))
+}

--- a/providers/aws/environments/stg/24-ecs-stop-scheduler/.terraform.lock.hcl
+++ b/providers/aws/environments/stg/24-ecs-stop-scheduler/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.58.0"
+  constraints = "4.58.0"
+  hashes = [
+    "h1:xXjZy36R+YOFyLjuF+rgi0NDLwnkFwrJ2t9NfsjRM/E=",
+    "zh:14b2b2dfbc7ee705c412d762b1485ee08958c816a64ac74f5769e946e4a1d265",
+    "zh:17a37e6825e2023b18987d31c0cbb9336654ea146b68e6c90710ea4636af71ae",
+    "zh:273127c69fb244577e5c136c46164d34f77b0c956c18d27f63d1072dd558f924",
+    "zh:4b2b6416d34fb3e1051c99d2a84045b136976140e34381d5fbf90e32db15272e",
+    "zh:7e6a8571ff15d51f892776265642ee01004b8553fd4f6f2014b6f3f2834670c7",
+    "zh:847c76ab2381b66666d0f79cf1ac697b5bfd0d9c3009fd11bc6ad6545d1eb427",
+    "zh:9a52cae08ba8d27d0639a8d2b8c61591027883058bf0cc5a639cffe1e299f019",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9df647e8322d6f94f1843366ba39d21c4b36c8e7dcdc03711d52e27f73b0e974",
+    "zh:9e52037e68409802ff913b166c30e3f2035af03865cbef0c1b03762bce853941",
+    "zh:a30288e7c3c904d6998d1709835d7c5800a739f8608f0837f960286a2b8b6e59",
+    "zh:a7f24e3bda3be566468e4ad62cef1016f68c6f5a94d2e3e979485bc05626281b",
+    "zh:ba326ba80f5e39829b67a6d1ce54ba52b171e5e13a0a91ef5f9170a9b0cc9ce4",
+    "zh:c4e3fe9f2be6e244a3dfce599f4b0be9e8fffaece64cbc65f3195f825f65489b",
+    "zh:f20a251af37039bb2c7612dbd2c5df3a25886b4cc78f902385a2850ea6e30d08",
+  ]
+}

--- a/providers/aws/environments/stg/24-ecs-stop-scheduler/backend.tf
+++ b/providers/aws/environments/stg/24-ecs-stop-scheduler/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket  = "stg-lgtm-cat-tfstate"
+    key     = "ecs-stop-scheduler/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "lgtm-cat"
+  }
+}

--- a/providers/aws/environments/stg/24-ecs-stop-scheduler/main.tf
+++ b/providers/aws/environments/stg/24-ecs-stop-scheduler/main.tf
@@ -1,0 +1,6 @@
+module "ecs_stop_scheduler" {
+  source = "../../../../../modules/aws/ecs-stop-scheduler"
+
+  env         = local.env
+  ecs_targets = local.ecs_targets
+}

--- a/providers/aws/environments/stg/24-ecs-stop-scheduler/provider.tf
+++ b/providers/aws/environments/stg/24-ecs-stop-scheduler/provider.tf
@@ -1,0 +1,4 @@
+provider "aws" {
+  region  = "ap-northeast-1"
+  profile = "lgtm-cat"
+}

--- a/providers/aws/environments/stg/24-ecs-stop-scheduler/variables.tf
+++ b/providers/aws/environments/stg/24-ecs-stop-scheduler/variables.tf
@@ -1,0 +1,6 @@
+locals {
+  env = "stg"
+  ecs_targets = [
+    { cluster = "${local.env}-lgtm-cat-api", service = "${local.env}-lgtm-cat-api" },
+  ]
+}

--- a/providers/aws/environments/stg/24-ecs-stop-scheduler/versions.tf
+++ b/providers/aws/environments/stg/24-ecs-stop-scheduler/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = "1.0.3"
+
+  required_providers {
+    aws = "4.58.0"
+  }
+}


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-terraform/issues/96

# Doneの定義
https://github.com/nekochans/lgtm-cat-terraform/issues/96 の完了条件を満たしていること

# 変更点概要
STG の ECS を1日1回停止する EventBridge Scheduler を構築。
停止時間は、夜間に作業することも考えられるため日本時間 AM 3:00 とした。

# レビュアーに重点的にチェックして欲しい点
インラインコメントも合わせて確認よろしくです！