### PR TITLE
Terraform の Provider Plugin をキャッシュする

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,16 @@ Your configuration already matches the changes detected above. If you'd like to 
 
 このように `No changes. Your infrastructure matches the configuration.` が表示されている場合は `terraform apply -refresh-only` を実行して下さい。
 
+## Provider Plugin Cache
+
+Provider Plugin Cache 機能を有効化しています。 機能については、以下のドキュメントを参考にしてください。
+
+[Provider Plugin Cache](https://developer.hashicorp.com/terraform/cli/config/config-file#provider-plugin-cache)
+
+ドキュメントにも記載されていますが、キャッシュされたプラグインは Terraform によって削除されることはありません。
+
+未使用のプラグインは手動で削除してください。
+
 ## ECS Exec
 
 踏み台用の ECS Cluster を構築しています。

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,3 +8,6 @@ services:
     volumes:
       - .:/data
       - $HOME/.aws:/root/.aws
+      - $HOME/.terraform.d/plugin-cache:/.plugin-cache
+    environment:
+      - TF_PLUGIN_CACHE_DIR=/.plugin-cache


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-terraform/issues/98

# Doneの定義
https://github.com/nekochans/lgtm-cat-terraform/issues/98 の完了の定義を満たしていること

# 変更点概要
Provider Plugin をキャッシュするために Docker 環境に TF_PLUGIN_CACHE_DIR 環境変数を追加。
以下の通り変更されていることを確認。

- terraform init した際に `Using hashicorp/aws v4.5.0 from the shared cache directory` キャッシュが利用されている
    - `terraform init` の実行時間も短くなった
```
Initializing modules...
- migration in ../../../../../modules/aws/ecs-migration

Initializing the backend...

Successfully configured the backend "s3"! Terraform will automatically
use this backend unless the backend configuration changes.

Initializing provider plugins...
- terraform.io/builtin/terraform is built in to Terraform
- Reusing previous version of hashicorp/aws from the dependency lock file
- Using hashicorp/aws v4.5.0 from the shared cache directory
```

- ディスク使用量 (`du -sh` の結果)
3.8G -> 243M