### PR TITLE
S3 + Cloudfrontのアクセス制御にはOrigin Access Control (OAC)を利用するように変更

### DIFF
--- a/modules/aws/images/main.tf
+++ b/modules/aws/images/main.tf
@@ -47,6 +47,22 @@ data "aws_iam_policy_document" "read_lgtm_images" {
       type        = "AWS"
     }
   }
+
+  statement {
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.lgtm_images_bucket.arn}/*"]
+
+    principals {
+      identifiers = ["cloudfront.amazonaws.com"]
+      type        = "Service"
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceArn"
+      values   = [aws_cloudfront_distribution.lgtm_images_cdn.arn]
+    }
+  }
 }
 
 resource "aws_s3_bucket_policy" "read_lgtm_images" {

--- a/modules/aws/images/main.tf
+++ b/modules/aws/images/main.tf
@@ -27,6 +27,13 @@ resource "aws_cloudfront_origin_access_identity" "lgtm_images_bucket" {
   comment = "${aws_s3_bucket.lgtm_images_bucket.bucket} origin access identity"
 }
 
+resource "aws_cloudfront_origin_access_control" "lgtm_images_bucket" {
+  name                              = "${var.lgtm_images_bucket_name}-oac"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
 data "aws_iam_policy_document" "read_lgtm_images" {
   statement {
     actions   = ["s3:GetObject"]

--- a/modules/aws/images/main.tf
+++ b/modules/aws/images/main.tf
@@ -115,9 +115,7 @@ resource "aws_cloudfront_distribution" "lgtm_images_cdn" {
     domain_name = aws_s3_bucket.lgtm_images_bucket.bucket_domain_name
     origin_id   = "S3-${aws_s3_bucket.lgtm_images_bucket.bucket}"
 
-    s3_origin_config {
-      origin_access_identity = aws_cloudfront_origin_access_identity.lgtm_images_bucket.cloudfront_access_identity_path
-    }
+    origin_access_control_id = aws_cloudfront_origin_access_control.lgtm_images_bucket.id
 
     custom_header {
       name  = "Accept"

--- a/modules/aws/images/main.tf
+++ b/modules/aws/images/main.tf
@@ -40,26 +40,6 @@ data "aws_iam_policy_document" "read_lgtm_images" {
     resources = ["${aws_s3_bucket.lgtm_images_bucket.arn}/*"]
 
     principals {
-      identifiers = [aws_cloudfront_origin_access_identity.lgtm_images_bucket.iam_arn]
-      type        = "AWS"
-    }
-  }
-
-  statement {
-    actions   = ["s3:ListBucket"]
-    resources = [aws_s3_bucket.lgtm_images_bucket.arn]
-
-    principals {
-      identifiers = [aws_cloudfront_origin_access_identity.lgtm_images_bucket.iam_arn]
-      type        = "AWS"
-    }
-  }
-
-  statement {
-    actions   = ["s3:GetObject"]
-    resources = ["${aws_s3_bucket.lgtm_images_bucket.arn}/*"]
-
-    principals {
       identifiers = ["cloudfront.amazonaws.com"]
       type        = "Service"
     }


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-terraform/issues/100

# Doneの定義
https://github.com/nekochans/lgtm-cat-terraform/issues/100 の完了条件が満たされていること

# 変更点概要
S3 + Cloudfrontのアクセス制御にOrigin Access Identity (OAI)からOrigin Access Control (OAC)を利用するように変更。
移行の手順は、公式のドキュメントを参考にした。

[Migrating from origin access identity (OAI) to origin access control (OAC)](https://docs.aws.amazon.com/en_us/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-s3.html#migrate-from-oai-to-oac)

具体的な手順は下記の通り
- [OAIからOACに移行するために、一時的にS3のポリシーをOAIとOACの両方からのアクセスを許可するように変更](https://github.com/nekochans/lgtm-cat-terraform/commit/a7dce4bc6bb79933aaaf8a72321712c87697a1d6)
- [OAIから移行するために新規でOACを作成](https://github.com/nekochans/lgtm-cat-terraform/commit/b0f9e7d505ee143b2e9578f90883b03d7a368abb)
- [CloudFrontからS3へのアクセス制御をOAIからOACに変更](https://github.com/nekochans/lgtm-cat-terraform/commit/5dea6ae13b9b348d6ddd8962c9c08d123b9205b2)
    - `terraform apply`を実行しようとするとS3バケットポリシーも差分が発生したので、ターゲットにCloudFrontを指定して`terraform apply`を実行
- [S3バケットポリシーからAOIによるアクセス許可を削除](https://github.com/nekochans/lgtm-cat-terraform/commit/8200a7359632f87bbca4571d49be7b0f5218f87f)

S3 + Cloudfront で配信している画像が表示されていることを確認。