### PR TITLE
Amazon Aurora DBをPlanetScaleにインポートするための設定を追加

### DIFF
--- a/modules/aws/rds/main.tf
+++ b/modules/aws/rds/main.tf
@@ -102,8 +102,27 @@ resource "aws_rds_cluster_parameter_group" "rds_cluster_parameter_group" {
     value = "Asia/Tokyo"
   }
 
-  lifecycle {
-    ignore_changes = all
+  parameter {
+    name  = "gtid-mode"
+    value = "ON"
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name  = "enforce_gtid_consistency"
+    value = "ON"
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name  = "sql_mode"
+    value = "NO_ZERO_IN_DATE,NO_ZERO_DATE,ONLY_FULL_GROUP_BY"
+  }
+
+  parameter {
+    name  = "binlog_format"
+    value = "ROW"
+    apply_method = "pending-reboot"
   }
 }
 

--- a/modules/aws/rds/main.tf
+++ b/modules/aws/rds/main.tf
@@ -104,14 +104,14 @@ resource "aws_rds_cluster_parameter_group" "rds_cluster_parameter_group" {
   }
 
   parameter {
-    name  = "gtid-mode"
-    value = "ON"
+    name         = "gtid-mode"
+    value        = "ON"
     apply_method = "pending-reboot"
   }
 
   parameter {
-    name  = "enforce_gtid_consistency"
-    value = "ON"
+    name         = "enforce_gtid_consistency"
+    value        = "ON"
     apply_method = "pending-reboot"
   }
 
@@ -121,8 +121,8 @@ resource "aws_rds_cluster_parameter_group" "rds_cluster_parameter_group" {
   }
 
   parameter {
-    name  = "binlog_format"
-    value = "ROW"
+    name         = "binlog_format"
+    value        = "ROW"
     apply_method = "pending-reboot"
   }
 }

--- a/modules/aws/rds/main.tf
+++ b/modules/aws/rds/main.tf
@@ -31,6 +31,7 @@ resource "aws_rds_cluster_instance" "rds_cluster_instance" {
   monitoring_role_arn     = aws_iam_role.rds_monitoring_role.arn
   monitoring_interval     = 60
   availability_zone       = each.value
+  publicly_accessible     = true
 }
 
 resource "aws_db_subnet_group" "rds_subnet_group" {


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-terraform/issues/106

# Doneの定義
https://github.com/nekochans/lgtm-cat-terraform/issues/106 の完了の定義のうち、terraformの修正が必要となる以下の2つが完了していること

> * GTID, sql_mode, binlog の設定が下記の設定に変更する
>   * gtid-mode: ON
>   * enforce_gtid_consistency: ON
>   * sql_mode: NO_ZERO_IN_DATE,NO_ZERO_DATE,ONLY_FULL_GROUP_BY
>   * binlog_format: ROW
>* ライターインスタンスの`Publicly Accessible`を有効にする

# 変更点概要
- [PlanetScaleへのインポートに必要となるRDSパラメータグループの設定を追加](https://github.com/nekochans/lgtm-cat-terraform/commit/d1ad3b26969cd99b229c18d780b57244bb2af3cd)
- [PlanetScaleへのインポートするためRDSライターインスタンスのPublicly Accessibleを有効化](https://github.com/nekochans/lgtm-cat-terraform/commit/522b384b7955237244ceac4b4e88b6929e5b5310)

# 補足情報
パラメータグループの変更を反映させるためには、ライターインスタンスのrebootが必要となる。
DBにアクセスできない時間が発生するためユーザーが存在しない時間帯に行う予定。
