### PR TITLE
LGTM画像を作成する処理の実行環境を構築

### DIFF
--- a/modules/aws/images/main.tf
+++ b/modules/aws/images/main.tf
@@ -10,6 +10,11 @@ resource "aws_s3_bucket" "cat_images_bucket" {
   force_destroy = true
 }
 
+resource "aws_s3_bucket_notification" "cat_images_bucket" {
+  bucket      = aws_s3_bucket.cat_images_bucket.id // 最終的にはupload_images_bucketを指定する
+  eventbridge = true
+}
+
 resource "aws_s3_bucket" "created_lgtm_images_bucket" {
   bucket = var.created_lgtm_images_bucket_name
 

--- a/modules/aws/lgtm-image-processor/cloudwatch.tf
+++ b/modules/aws/lgtm-image-processor/cloudwatch.tf
@@ -1,0 +1,4 @@
+resource "aws_cloudwatch_log_group" "lgtm_image_processor" {
+  name              = "/aws/lambda/${var.lambda_function_name}"
+  retention_in_days = var.log_retention_in_days
+}

--- a/modules/aws/lgtm-image-processor/ecr.tf
+++ b/modules/aws/lgtm-image-processor/ecr.tf
@@ -1,0 +1,31 @@
+resource "aws_ecr_repository" "lgtm_image_processor" {
+  name                 = var.ecr_name
+  image_tag_mutability = "MUTABLE"
+}
+
+locals {
+  lifecycle_policy = <<EOF
+  {
+    "rules": [
+      {
+        "rulePriority": 10,
+        "description": "Expire images count more than 5",
+        "selection": {
+          "tagStatus": "any",
+          "countType": "imageCountMoreThan",
+          "countNumber": 5
+        },
+        "action": {
+          "type": "expire"
+        }
+      }
+    ]
+  }
+EOF
+
+}
+
+resource "aws_ecr_lifecycle_policy" "lgtm_image_processor" {
+  repository = aws_ecr_repository.lgtm_image_processor.name
+  policy     = local.lifecycle_policy
+}

--- a/modules/aws/lgtm-image-processor/eventbridge-rule.tf
+++ b/modules/aws/lgtm-image-processor/eventbridge-rule.tf
@@ -1,0 +1,25 @@
+resource "aws_cloudwatch_event_rule" "lgtm_image_processor" {
+  name = var.eventbridge_rule_name
+  event_pattern = jsonencode({
+    "source" : [
+      "aws.s3"
+    ],
+    "detail-type" : [
+      "Object Created"
+    ],
+    "detail" : {
+      "bucket" : {
+        "name" : [
+          var.upload_images_bucket
+        ]
+      }
+    }
+  })
+}
+
+resource "aws_cloudwatch_event_target" "step_functions" {
+  rule      = aws_cloudwatch_event_rule.lgtm_image_processor.name
+  target_id = var.eventbridge_rule_target_id
+  arn       = aws_sfn_state_machine.lgtm_image_processor.arn
+  role_arn  = aws_iam_role.eventbridge.arn
+}

--- a/modules/aws/lgtm-image-processor/files/step-function.json
+++ b/modules/aws/lgtm-image-processor/files/step-function.json
@@ -1,22 +1,6 @@
 {
-  "StartAt": "judgeImage",
+  "StartAt": "generateLgtmImage",
   "States": {
-    "judgeImage": {
-      "Type": "Task",
-      "Resource": "arn:aws:states:::lambda:invoke",
-      "OutputPath": "$.Payload",
-      "Parameters": {
-        "FunctionName": "${lambda_arn}:$LATEST",
-        "Payload": {
-          "process": "judgeImage",
-          "image": {
-            "bucketName.$": "$.detail.bucket.name",
-            "objectKey.$": "$.detail.object.key"
-          }
-        }
-      },
-      "Next": "generateLgtmImage"
-    },
     "generateLgtmImage": {
       "Type": "Task",
       "Resource": "arn:aws:states:::lambda:invoke",
@@ -26,8 +10,8 @@
         "Payload": {
           "process": "generateLgtmImage",
           "image": {
-            "bucketName.$": "$.image.bucketName",
-            "objectKey.$": "$.image.objectKey"
+            "bucketName.$": "$.detail.bucket.name",
+            "objectKey.$": "$.detail.object.key"
           }
         }
       },
@@ -40,7 +24,23 @@
       "Parameters": {
         "FunctionName": "${lambda_arn}:$LATEST",
         "Payload": {
-          "process": "generateLgtmImage",
+          "process": "convertToWebp",
+          "image": {
+            "bucketName.$": "$.image.bucketName",
+            "objectKey.$": "$.image.objectKey"
+          }
+        }
+      },
+      "Next": "storeToDb"
+    },
+    "storeToDb": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "OutputPath": "$.Payload",
+      "Parameters": {
+        "FunctionName": "${lambda_arn}:$LATEST",
+        "Payload": {
+          "process": "storeToDb",
           "image": {
             "bucketName.$": "$.image.bucketName",
             "objectKey.$": "$.image.objectKey"

--- a/modules/aws/lgtm-image-processor/files/step-function.json
+++ b/modules/aws/lgtm-image-processor/files/step-function.json
@@ -1,0 +1,53 @@
+{
+  "StartAt": "judgeImage",
+  "States": {
+    "judgeImage": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "OutputPath": "$.Payload",
+      "Parameters": {
+        "FunctionName": "${lambda_arn}:$LATEST",
+        "Payload": {
+          "process": "judgeImage",
+          "image": {
+            "bucketName.$": "$.detail.bucket.name",
+            "objectKey.$": "$.detail.object.key"
+          }
+        }
+      },
+      "Next": "generateLgtmImage"
+    },
+    "generateLgtmImage": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "OutputPath": "$.Payload",
+      "Parameters": {
+        "FunctionName": "${lambda_arn}:$LATEST",
+        "Payload": {
+          "process": "generateLgtmImage",
+          "image": {
+            "bucketName.$": "$.image.bucketName",
+            "objectKey.$": "$.image.objectKey"
+          }
+        }
+      },
+      "Next": "convertToWebp"
+    },
+    "convertToWebp": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "OutputPath": "$.Payload",
+      "Parameters": {
+        "FunctionName": "${lambda_arn}:$LATEST",
+        "Payload": {
+          "process": "generateLgtmImage",
+          "image": {
+            "bucketName.$": "$.image.bucketName",
+            "objectKey.$": "$.image.objectKey"
+          }
+        }
+      },
+      "End": true
+    }
+  }
+}

--- a/modules/aws/lgtm-image-processor/iam.tf
+++ b/modules/aws/lgtm-image-processor/iam.tf
@@ -1,0 +1,20 @@
+data "aws_iam_policy_document" "lambda_assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    effect  = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "lambda" {
+  name               = var.lambda_iam_role_name
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_basic" {
+  role       = aws_iam_role.lambda.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}

--- a/modules/aws/lgtm-image-processor/iam.tf
+++ b/modules/aws/lgtm-image-processor/iam.tf
@@ -18,3 +18,50 @@ resource "aws_iam_role_policy_attachment" "lambda_basic" {
   role       = aws_iam_role.lambda.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
 }
+
+#StepFunctions
+data "aws_iam_policy_document" "step_functions_assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    effect  = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["states.amazonaws.com"]
+    }
+  }
+}
+resource "aws_iam_role" "step_functions" {
+  name               = var.stepfunctions_iam_role_name
+  assume_role_policy = data.aws_iam_policy_document.step_functions_assume_role.json
+}
+
+resource "aws_iam_policy" "step_functions" {
+  name = var.stepfunctions_iam_policy_name
+
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "logs:CreateLogStream",
+          "logs:CreateLogGroup",
+          "logs:PutLogEvents",
+        ],
+        "Resource" : "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/*"
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "lambda:InvokeFunction",
+        ],
+        "Resource" : "arn:aws:lambda:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:function:${var.lambda_function_name}:*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "step_functions_policy_attachment" {
+  role       = aws_iam_role.step_functions.id
+  policy_arn = aws_iam_policy.step_functions.arn
+}

--- a/modules/aws/lgtm-image-processor/lambda.tf
+++ b/modules/aws/lgtm-image-processor/lambda.tf
@@ -1,0 +1,18 @@
+resource "aws_lambda_function" "lgtm_image_processor" {
+  function_name = var.lambda_function_name
+  package_type  = "Image"
+  image_uri     = "${aws_ecr_repository.lgtm_image_processor.repository_url}:latest"
+  role          = aws_iam_role.lambda.arn
+
+  architectures = ["arm64"]
+  memory_size   = 128
+  timeout       = 30
+
+  lifecycle {
+    ignore_changes = [
+      last_modified,
+      image_uri,
+      version,
+    ]
+  }
+}

--- a/modules/aws/lgtm-image-processor/stepfunctions.tf
+++ b/modules/aws/lgtm-image-processor/stepfunctions.tf
@@ -1,0 +1,8 @@
+resource "aws_sfn_state_machine" "lgtm_image_processor" {
+  name     = var.stepfunctions_name
+  role_arn = aws_iam_role.step_functions.arn
+
+  definition = templatefile("${path.module}/files/step-function.json", {
+    lambda_arn = aws_lambda_function.lgtm_image_processor.arn
+  })
+}

--- a/modules/aws/lgtm-image-processor/variables.tf
+++ b/modules/aws/lgtm-image-processor/variables.tf
@@ -1,0 +1,15 @@
+variable "ecr_name" {
+  type = string
+}
+
+variable "lambda_function_name" {
+  type = string
+}
+
+variable "lambda_iam_role_name" {
+  type = string
+}
+
+variable "log_retention_in_days" {
+  type = number
+}

--- a/modules/aws/lgtm-image-processor/variables.tf
+++ b/modules/aws/lgtm-image-processor/variables.tf
@@ -13,3 +13,18 @@ variable "lambda_iam_role_name" {
 variable "log_retention_in_days" {
   type = number
 }
+
+variable "stepfunctions_name" {
+  type = string
+}
+
+variable "stepfunctions_iam_role_name" {
+  type = string
+}
+
+variable "stepfunctions_iam_policy_name" {
+  type = string
+}
+
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}

--- a/modules/aws/lgtm-image-processor/variables.tf
+++ b/modules/aws/lgtm-image-processor/variables.tf
@@ -26,5 +26,25 @@ variable "stepfunctions_iam_policy_name" {
   type = string
 }
 
+variable "eventbridge_rule_name" {
+  type = string
+}
+
+variable "eventbridge_rule_target_id" {
+  type = string
+}
+
+variable "upload_images_bucket" {
+  type = string
+}
+
+variable "eventbridge_iam_role_name" {
+  type = string
+}
+
+variable "eventbridge_iam_policy_name" {
+  type = string
+}
+
 data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}

--- a/providers/aws/environments/stg/22-lgtm-image-processor/.terraform.lock.hcl
+++ b/providers/aws/environments/stg/22-lgtm-image-processor/.terraform.lock.hcl
@@ -1,0 +1,10 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.1.0"
+  constraints = "5.1.0"
+  hashes = [
+    "h1:cD/xic4fsOb2yPp4UARXqzjN8frK9QSxLM4cPfYz8Hg=",
+  ]
+}

--- a/providers/aws/environments/stg/22-lgtm-image-processor/backend.tf
+++ b/providers/aws/environments/stg/22-lgtm-image-processor/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket  = "stg-lgtm-cat-tfstate"
+    key     = "lgtm-image-processor/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "lgtm-cat"
+  }
+}

--- a/providers/aws/environments/stg/22-lgtm-image-processor/main.tf
+++ b/providers/aws/environments/stg/22-lgtm-image-processor/main.tf
@@ -8,4 +8,9 @@ module "lgtm_image_processor" {
   stepfunctions_name            = local.stepfunctions_name
   stepfunctions_iam_policy_name = local.stepfunctions_iam_policy_name
   stepfunctions_iam_role_name   = local.stepfunctions_iam_role_name
+  eventbridge_rule_name         = local.eventbridge_rule_name
+  eventbridge_rule_target_id    = local.eventbridge_rule_target_id
+  eventbridge_iam_role_name     = local.eventbridge_iam_role_name
+  eventbridge_iam_policy_name   = local.eventbridge_iam_policy_name
+  upload_images_bucket          = local.upload_images_bucket
 }

--- a/providers/aws/environments/stg/22-lgtm-image-processor/main.tf
+++ b/providers/aws/environments/stg/22-lgtm-image-processor/main.tf
@@ -1,8 +1,11 @@
 module "lgtm_image_processor" {
   source = "../../../../../modules/aws/lgtm-image-processor"
 
-  ecr_name              = local.ecr_name
-  lambda_function_name  = local.lambda_function_name
-  lambda_iam_role_name  = local.lambda_iam_role_name
-  log_retention_in_days = local.log_retention_in_days
+  ecr_name                      = local.ecr_name
+  lambda_function_name          = local.lambda_function_name
+  lambda_iam_role_name          = local.lambda_iam_role_name
+  log_retention_in_days         = local.log_retention_in_days
+  stepfunctions_name            = local.stepfunctions_name
+  stepfunctions_iam_policy_name = local.stepfunctions_iam_policy_name
+  stepfunctions_iam_role_name   = local.stepfunctions_iam_role_name
 }

--- a/providers/aws/environments/stg/22-lgtm-image-processor/main.tf
+++ b/providers/aws/environments/stg/22-lgtm-image-processor/main.tf
@@ -1,0 +1,8 @@
+module "lgtm_image_processor" {
+  source = "../../../../../modules/aws/lgtm-image-processor"
+
+  ecr_name              = local.ecr_name
+  lambda_function_name  = local.lambda_function_name
+  lambda_iam_role_name  = local.lambda_iam_role_name
+  log_retention_in_days = local.log_retention_in_days
+}

--- a/providers/aws/environments/stg/22-lgtm-image-processor/provider.tf
+++ b/providers/aws/environments/stg/22-lgtm-image-processor/provider.tf
@@ -1,0 +1,4 @@
+provider "aws" {
+  region  = "ap-northeast-1"
+  profile = "lgtm-cat"
+}

--- a/providers/aws/environments/stg/22-lgtm-image-processor/variables.tf
+++ b/providers/aws/environments/stg/22-lgtm-image-processor/variables.tf
@@ -1,0 +1,8 @@
+locals {
+  env = "stg"
+
+  ecr_name              = "${local.env}-lgtm-image-processor"
+  lambda_function_name  = "${local.env}-lgtm-image-processor"
+  lambda_iam_role_name  = "${local.env}-lgtm-image-processor-lambda-role"
+  log_retention_in_days = 3
+}

--- a/providers/aws/environments/stg/22-lgtm-image-processor/variables.tf
+++ b/providers/aws/environments/stg/22-lgtm-image-processor/variables.tf
@@ -10,4 +10,10 @@ locals {
   stepfunctions_name            = "${local.env}-${local.service_name}-invoke"
   stepfunctions_iam_role_name   = "${local.env}-stepfunctions-${local.service_name}-lambda-invoke-role"
   stepfunctions_iam_policy_name = "${local.env}-stepfunctions-${local.service_name}-lambda-invoke-policy"
+
+  eventbridge_rule_name       = "${local.env}-${local.service_name}-rule"
+  eventbridge_rule_target_id  = "${local.env}-${local.service_name}-stepfunctions-invoke"
+  eventbridge_iam_role_name   = "${local.env}-eventbridge-${local.service_name}-invoke-stepfunctions--role"
+  eventbridge_iam_policy_name = "${local.env}-eventbridge-${local.service_name}-invoke-stepfunctions--policy"
+  upload_images_bucket        = "${local.env}-lgtmeow-cat-images"
 }

--- a/providers/aws/environments/stg/22-lgtm-image-processor/variables.tf
+++ b/providers/aws/environments/stg/22-lgtm-image-processor/variables.tf
@@ -1,8 +1,13 @@
 locals {
-  env = "stg"
+  env          = "stg"
+  service_name = "lgtm-image-processor"
 
-  ecr_name              = "${local.env}-lgtm-image-processor"
-  lambda_function_name  = "${local.env}-lgtm-image-processor"
-  lambda_iam_role_name  = "${local.env}-lgtm-image-processor-lambda-role"
+  ecr_name              = "${local.env}-${local.service_name}"
+  lambda_function_name  = "${local.env}-${local.service_name}"
+  lambda_iam_role_name  = "${local.env}-${local.service_name}-lambda-role"
   log_retention_in_days = 3
+
+  stepfunctions_name            = "${local.env}-${local.service_name}-invoke"
+  stepfunctions_iam_role_name   = "${local.env}-stepfunctions-${local.service_name}-lambda-invoke-role"
+  stepfunctions_iam_policy_name = "${local.env}-stepfunctions-${local.service_name}-lambda-invoke-policy"
 }

--- a/providers/aws/environments/stg/22-lgtm-image-processor/versions.tf
+++ b/providers/aws/environments/stg/22-lgtm-image-processor/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = "1.0.3"
+
+  required_providers {
+    aws = "5.1.0"
+  }
+}


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-terraform/issues/112

# 関連URL
StepFunctionsから実行されるLambdaのPR
https://github.com/nekochans/lgtm-cat-processor/issues/3

# Doneの定義
https://github.com/nekochans/lgtm-cat-terraform/issues/112 の完了の定義が満たされていること

# 変更点概要
S3バケットに画像がアップロードされた際に、非同期でLGTM画像を作成する処理の実行環境を構築。

## 具体的なリソース

- LGTM画像を作成する各工程を実行するコンテナLambdaを新規作成
- コンテナLambdaを実行するStepFunctionsを新規作成
- StepFunctionsを実行するEventBridge ruleを新規作成
- 既存のS3バケットのEventBridgeへイベントを通知するための設定を有効化
    - リリースの第一弾では、猫画像の判定処理を行なっているLambdaについては現状のままとするため、画像判定後にアップロードされるS3バケットに設定 

## StepFunctionsについて
LGTM画像を作成するために複数の工程が必要となるが、この処理は1つのLambdaで実行する。
これを実現するために、Lambdaに以下のようなペイロードを渡す。
Lmbdaはペイロードをハンドラーのeventとして受け取り、`process`の値に応じて必要な処理を実行する

```
{
  "process": "judgeImage",
  "image": {
    "bucketName": "test-lgtmeow-cat-images",
    "objectKey": "2024/image.jpg"    
  }
}
```

## 動作確認
S3バケットに画像をアップロードし、StepFunctionsステートマシンが動くことを確認。
<img width="430" alt="スクリーンショット 2024-08-29 21 29 18" src="https://github.com/user-attachments/assets/7238edc0-372a-45f1-a887-372c922a15a1">

