### PR TITLE
lgtm-cat-processerのLambdaに環境変数を追加

### DIFF
--- a/modules/aws/lgtm-image-processor/lambda.tf
+++ b/modules/aws/lgtm-image-processor/lambda.tf
@@ -13,6 +13,10 @@ resource "aws_lambda_function" "lgtm_image_processor" {
       JUDGE_IMAGE_UPLOAD_BUCKET         = var.judge_image_upload_bucket
       GENERATE_LGTM_IMAGE_UPLOAD_BUCKET = var.generate_lgtm_image_upload_bucket
       CONVERT_TO_WEBP_UPLOAD_BUCKET     = var.convert_to_webp_upload_bucket
+      DB_HOSTNAME                       = jsondecode(data.aws_secretsmanager_secret_version.secret.secret_string)["db_host"]
+      DB_USERNAME                       = jsondecode(data.aws_secretsmanager_secret_version.secret.secret_string)["db_app_user"]
+      DB_PASSWORD                       = jsondecode(data.aws_secretsmanager_secret_version.secret.secret_string)["db_app_password"]
+      DB_NAME                           = jsondecode(data.aws_secretsmanager_secret_version.secret.secret_string)["db_name"]
     }
   }
 

--- a/modules/aws/lgtm-image-processor/lambda.tf
+++ b/modules/aws/lgtm-image-processor/lambda.tf
@@ -8,6 +8,14 @@ resource "aws_lambda_function" "lgtm_image_processor" {
   memory_size   = 128
   timeout       = 30
 
+  environment {
+    variables = {
+      JUDGE_IMAGE_UPLOAD_BUCKET         = var.judge_image_upload_bucket
+      GENERATE_LGTM_IMAGE_UPLOAD_BUCKET = var.generate_lgtm_image_upload_bucket
+      CONVERT_TO_WEBP_UPLOAD_BUCKET     = var.convert_to_webp_upload_bucket
+    }
+  }
+
   lifecycle {
     ignore_changes = [
       last_modified,

--- a/modules/aws/lgtm-image-processor/variables.tf
+++ b/modules/aws/lgtm-image-processor/variables.tf
@@ -60,3 +60,11 @@ variable "convert_to_webp_upload_bucket" {
 
 data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}
+
+data "aws_secretsmanager_secret" "secret" {
+  name = "/stg/lgtm-cat"
+}
+
+data "aws_secretsmanager_secret_version" "secret" {
+  secret_id = data.aws_secretsmanager_secret.secret.id
+}

--- a/modules/aws/lgtm-image-processor/variables.tf
+++ b/modules/aws/lgtm-image-processor/variables.tf
@@ -46,5 +46,17 @@ variable "eventbridge_iam_policy_name" {
   type = string
 }
 
+variable "judge_image_upload_bucket" {
+  type = string
+}
+
+variable "generate_lgtm_image_upload_bucket" {
+  type = string
+}
+
+variable "convert_to_webp_upload_bucket" {
+  type = string
+}
+
 data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}

--- a/modules/aws/lgtm-image-processor/variables.tf
+++ b/modules/aws/lgtm-image-processor/variables.tf
@@ -1,3 +1,7 @@
+variable "env" {
+  type = string
+}
+
 variable "ecr_name" {
   type = string
 }
@@ -62,7 +66,7 @@ data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}
 
 data "aws_secretsmanager_secret" "secret" {
-  name = "/stg/lgtm-cat"
+  name = "/${var.env}/lgtm-cat"
 }
 
 data "aws_secretsmanager_secret_version" "secret" {

--- a/providers/aws/environments/stg/22-lgtm-image-processor/main.tf
+++ b/providers/aws/environments/stg/22-lgtm-image-processor/main.tf
@@ -13,4 +13,8 @@ module "lgtm_image_processor" {
   eventbridge_iam_role_name     = local.eventbridge_iam_role_name
   eventbridge_iam_policy_name   = local.eventbridge_iam_policy_name
   upload_images_bucket          = local.upload_images_bucket
+
+  judge_image_upload_bucket         = local.judge_image_upload_bucket
+  generate_lgtm_image_upload_bucket = local.generate_lgtm_image_upload_bucket
+  convert_to_webp_upload_bucket     = local.convert_to_webp_upload_bucket
 }

--- a/providers/aws/environments/stg/22-lgtm-image-processor/main.tf
+++ b/providers/aws/environments/stg/22-lgtm-image-processor/main.tf
@@ -1,6 +1,7 @@
 module "lgtm_image_processor" {
   source = "../../../../../modules/aws/lgtm-image-processor"
 
+  env                           = local.env
   ecr_name                      = local.ecr_name
   lambda_function_name          = local.lambda_function_name
   lambda_iam_role_name          = local.lambda_iam_role_name

--- a/providers/aws/environments/stg/22-lgtm-image-processor/variables.tf
+++ b/providers/aws/environments/stg/22-lgtm-image-processor/variables.tf
@@ -16,4 +16,8 @@ locals {
   eventbridge_iam_role_name   = "${local.env}-eventbridge-${local.service_name}-invoke-stepfunctions--role"
   eventbridge_iam_policy_name = "${local.env}-eventbridge-${local.service_name}-invoke-stepfunctions--policy"
   upload_images_bucket        = "${local.env}-lgtmeow-cat-images"
+
+  judge_image_upload_bucket         = "${local.env}-lgtmeow-cat-images"
+  generate_lgtm_image_upload_bucket = "${local.env}-lgtmeow-created-lgtm-images"
+  convert_to_webp_upload_bucket     = "${local.env}-lgtmeow-images"
 }

--- a/providers/aws/environments/stg/22-lgtm-image-processor/variables.tf
+++ b/providers/aws/environments/stg/22-lgtm-image-processor/variables.tf
@@ -13,8 +13,8 @@ locals {
 
   eventbridge_rule_name       = "${local.env}-${local.service_name}-rule"
   eventbridge_rule_target_id  = "${local.env}-${local.service_name}-stepfunctions-invoke"
-  eventbridge_iam_role_name   = "${local.env}-eventbridge-${local.service_name}-invoke-stepfunctions--role"
-  eventbridge_iam_policy_name = "${local.env}-eventbridge-${local.service_name}-invoke-stepfunctions--policy"
+  eventbridge_iam_role_name   = "${local.env}-eventbridge-${local.service_name}-invoke-stepfunctions-role"
+  eventbridge_iam_policy_name = "${local.env}-eventbridge-${local.service_name}-invoke-stepfunctions-policy"
   upload_images_bucket        = "${local.env}-lgtmeow-cat-images"
 
   judge_image_upload_bucket         = "${local.env}-lgtmeow-cat-images"


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-terraform/issues/115

# Doneの定義
https://github.com/nekochans/lgtm-cat-terraform/issues/115 の完了の定義が満たされていること

# 変更点概要
lgtm-cat-processorのLambdaに以下の環境変数を追加

- S3バケット名
- DBへの接続情報

DBへの接続情報はLambdaの環境変数に設定するとAWSコンソールから閲覧できてしまうため、アプリケーション上でSecrets Managerから取得することも検討したが、最終的には環境変数に設定する形を選択した。その理由としては、開発者が2人のみであり、Lambda上から接続情報が確認できたとしても、大きなセキュリティリスクにはならないと判断したため。

また、Issueとは関係ないがリソースの名前に`--`となってしまっている箇所があったので修正を行った。
[IAM role,policy名がハイフンが重なってしまっていたので修正](https://github.com/nekochans/lgtm-cat-terraform/pull/116/commits/6e5ec87e613633dd8b1fe432f14c13d4fa024200)

# レビュアーに重点的にチェックして欲しい点
機密情報の扱いについて認識としてずれてないか。