### PR TITLE
lgtm-cat-processerのLambdaにS3の権限を付与

### DIFF
--- a/modules/aws/lgtm-image-processor/cloudwatch.tf
+++ b/modules/aws/lgtm-image-processor/cloudwatch.tf
@@ -1,4 +1,4 @@
 resource "aws_cloudwatch_log_group" "lgtm_image_processor" {
-  name              = "/aws/lambda/${var.lambda_function_name}"
+  name              = "/aws/lambda/${local.lambda_function_name}"
   retention_in_days = var.log_retention_in_days
 }

--- a/modules/aws/lgtm-image-processor/ecr.tf
+++ b/modules/aws/lgtm-image-processor/ecr.tf
@@ -1,5 +1,5 @@
 resource "aws_ecr_repository" "lgtm_image_processor" {
-  name                 = var.ecr_name
+  name                 = "${var.env}-${var.service_name}"
   image_tag_mutability = "MUTABLE"
 }
 

--- a/modules/aws/lgtm-image-processor/eventbridge-rule.tf
+++ b/modules/aws/lgtm-image-processor/eventbridge-rule.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudwatch_event_rule" "lgtm_image_processor" {
-  name = var.eventbridge_rule_name
+  name = "${var.env}-${var.service_name}-rule"
   event_pattern = jsonencode({
     "source" : [
       "aws.s3"
@@ -19,7 +19,7 @@ resource "aws_cloudwatch_event_rule" "lgtm_image_processor" {
 
 resource "aws_cloudwatch_event_target" "step_functions" {
   rule      = aws_cloudwatch_event_rule.lgtm_image_processor.name
-  target_id = var.eventbridge_rule_target_id
+  target_id = "${var.env}-${var.service_name}-stepfunctions-invoke"
   arn       = aws_sfn_state_machine.lgtm_image_processor.arn
   role_arn  = aws_iam_role.eventbridge.arn
 }

--- a/modules/aws/lgtm-image-processor/iam.tf
+++ b/modules/aws/lgtm-image-processor/iam.tf
@@ -19,6 +19,30 @@ resource "aws_iam_role_policy_attachment" "lambda_basic" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
 }
 
+
+data "aws_iam_policy_document" "lambda_s3" {
+  statement {
+    effect  = "Allow"
+    actions = ["s3:*"]
+    resources = [
+      "arn:aws:s3:::${var.upload_images_bucket}",
+      "arn:aws:s3:::${var.upload_images_bucket}/*",
+      "arn:aws:s3:::${var.judge_image_upload_bucket}",
+      "arn:aws:s3:::${var.judge_image_upload_bucket}/*",
+      "arn:aws:s3:::${var.generate_lgtm_image_upload_bucket}",
+      "arn:aws:s3:::${var.generate_lgtm_image_upload_bucket}/*",
+      "arn:aws:s3:::${var.convert_to_webp_upload_bucket}",
+      "arn:aws:s3:::${var.convert_to_webp_upload_bucket}/*"
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "lambda_s3" {
+  name   = "${var.env}-${var.service_name}-lambda-s3-policy"
+  role   = aws_iam_role.lambda.id
+  policy = data.aws_iam_policy_document.lambda_s3.json
+}
+
 #StepFunctions
 data "aws_iam_policy_document" "step_functions_assume_role" {
   statement {

--- a/modules/aws/lgtm-image-processor/iam.tf
+++ b/modules/aws/lgtm-image-processor/iam.tf
@@ -10,7 +10,7 @@ data "aws_iam_policy_document" "lambda_assume_role" {
 }
 
 resource "aws_iam_role" "lambda" {
-  name               = var.lambda_iam_role_name
+  name               = "${var.env}-${var.service_name}-lambda-role"
   assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
 }
 
@@ -31,12 +31,12 @@ data "aws_iam_policy_document" "step_functions_assume_role" {
   }
 }
 resource "aws_iam_role" "step_functions" {
-  name               = var.stepfunctions_iam_role_name
+  name               = "${var.env}-stepfunctions-${var.service_name}-lambda-invoke-role"
   assume_role_policy = data.aws_iam_policy_document.step_functions_assume_role.json
 }
 
 resource "aws_iam_policy" "step_functions" {
-  name = var.stepfunctions_iam_policy_name
+  name = "${var.env}-stepfunctions-${var.service_name}-lambda-invoke-policy"
 
   policy = jsonencode({
     "Version" : "2012-10-17",
@@ -55,7 +55,7 @@ resource "aws_iam_policy" "step_functions" {
         "Action" : [
           "lambda:InvokeFunction",
         ],
-        "Resource" : "arn:aws:lambda:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:function:${var.lambda_function_name}:*"
+        "Resource" : "arn:aws:lambda:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:function:${local.lambda_function_name}:*"
       }
     ]
   })
@@ -81,7 +81,7 @@ data "aws_iam_policy_document" "assume_role" {
 
 # EventBridge
 resource "aws_iam_role" "eventbridge" {
-  name               = var.eventbridge_iam_role_name
+  name               = "${var.env}-eventbridge-${var.service_name}-invoke-stepfunctions-role"
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
@@ -94,7 +94,7 @@ data "aws_iam_policy_document" "eventbridge" {
 }
 
 resource "aws_iam_policy" "eventbridge" {
-  name   = var.eventbridge_iam_policy_name
+  name   = "${var.env}-eventbridge-${var.service_name}-invoke-stepfunctions-policy"
   policy = data.aws_iam_policy_document.eventbridge.json
 }
 

--- a/modules/aws/lgtm-image-processor/lambda.tf
+++ b/modules/aws/lgtm-image-processor/lambda.tf
@@ -1,5 +1,5 @@
 resource "aws_lambda_function" "lgtm_image_processor" {
-  function_name = var.lambda_function_name
+  function_name = local.lambda_function_name
   package_type  = "Image"
   image_uri     = "${aws_ecr_repository.lgtm_image_processor.repository_url}:latest"
   role          = aws_iam_role.lambda.arn

--- a/modules/aws/lgtm-image-processor/stepfunctions.tf
+++ b/modules/aws/lgtm-image-processor/stepfunctions.tf
@@ -1,5 +1,5 @@
 resource "aws_sfn_state_machine" "lgtm_image_processor" {
-  name     = var.stepfunctions_name
+  name     = "${var.env}-${var.service_name}-invoke"
   role_arn = aws_iam_role.step_functions.arn
 
   definition = templatefile("${path.module}/files/step-function.json", {

--- a/modules/aws/lgtm-image-processor/variables.tf
+++ b/modules/aws/lgtm-image-processor/variables.tf
@@ -2,15 +2,7 @@ variable "env" {
   type = string
 }
 
-variable "ecr_name" {
-  type = string
-}
-
-variable "lambda_function_name" {
-  type = string
-}
-
-variable "lambda_iam_role_name" {
+variable "service_name" {
   type = string
 }
 
@@ -18,35 +10,7 @@ variable "log_retention_in_days" {
   type = number
 }
 
-variable "stepfunctions_name" {
-  type = string
-}
-
-variable "stepfunctions_iam_role_name" {
-  type = string
-}
-
-variable "stepfunctions_iam_policy_name" {
-  type = string
-}
-
-variable "eventbridge_rule_name" {
-  type = string
-}
-
-variable "eventbridge_rule_target_id" {
-  type = string
-}
-
 variable "upload_images_bucket" {
-  type = string
-}
-
-variable "eventbridge_iam_role_name" {
-  type = string
-}
-
-variable "eventbridge_iam_policy_name" {
   type = string
 }
 
@@ -71,4 +35,8 @@ data "aws_secretsmanager_secret" "secret" {
 
 data "aws_secretsmanager_secret_version" "secret" {
   secret_id = data.aws_secretsmanager_secret.secret.id
+}
+
+locals {
+  lambda_function_name = "${var.env}-${var.service_name}"
 }

--- a/providers/aws/environments/stg/22-lgtm-image-processor/main.tf
+++ b/providers/aws/environments/stg/22-lgtm-image-processor/main.tf
@@ -1,20 +1,10 @@
 module "lgtm_image_processor" {
   source = "../../../../../modules/aws/lgtm-image-processor"
 
-  env                           = local.env
-  ecr_name                      = local.ecr_name
-  lambda_function_name          = local.lambda_function_name
-  lambda_iam_role_name          = local.lambda_iam_role_name
-  log_retention_in_days         = local.log_retention_in_days
-  stepfunctions_name            = local.stepfunctions_name
-  stepfunctions_iam_policy_name = local.stepfunctions_iam_policy_name
-  stepfunctions_iam_role_name   = local.stepfunctions_iam_role_name
-  eventbridge_rule_name         = local.eventbridge_rule_name
-  eventbridge_rule_target_id    = local.eventbridge_rule_target_id
-  eventbridge_iam_role_name     = local.eventbridge_iam_role_name
-  eventbridge_iam_policy_name   = local.eventbridge_iam_policy_name
-  upload_images_bucket          = local.upload_images_bucket
-
+  env                               = local.env
+  service_name                      = local.service_name
+  log_retention_in_days             = local.log_retention_in_days
+  upload_images_bucket              = local.upload_images_bucket
   judge_image_upload_bucket         = local.judge_image_upload_bucket
   generate_lgtm_image_upload_bucket = local.generate_lgtm_image_upload_bucket
   convert_to_webp_upload_bucket     = local.convert_to_webp_upload_bucket

--- a/providers/aws/environments/stg/22-lgtm-image-processor/variables.tf
+++ b/providers/aws/environments/stg/22-lgtm-image-processor/variables.tf
@@ -2,21 +2,8 @@ locals {
   env          = "stg"
   service_name = "lgtm-image-processor"
 
-  ecr_name              = "${local.env}-${local.service_name}"
-  lambda_function_name  = "${local.env}-${local.service_name}"
-  lambda_iam_role_name  = "${local.env}-${local.service_name}-lambda-role"
-  log_retention_in_days = 3
-
-  stepfunctions_name            = "${local.env}-${local.service_name}-invoke"
-  stepfunctions_iam_role_name   = "${local.env}-stepfunctions-${local.service_name}-lambda-invoke-role"
-  stepfunctions_iam_policy_name = "${local.env}-stepfunctions-${local.service_name}-lambda-invoke-policy"
-
-  eventbridge_rule_name       = "${local.env}-${local.service_name}-rule"
-  eventbridge_rule_target_id  = "${local.env}-${local.service_name}-stepfunctions-invoke"
-  eventbridge_iam_role_name   = "${local.env}-eventbridge-${local.service_name}-invoke-stepfunctions-role"
-  eventbridge_iam_policy_name = "${local.env}-eventbridge-${local.service_name}-invoke-stepfunctions-policy"
-  upload_images_bucket        = "${local.env}-lgtmeow-cat-images"
-
+  log_retention_in_days             = 3
+  upload_images_bucket              = "${local.env}-lgtmeow-cat-images"
   judge_image_upload_bucket         = "${local.env}-lgtmeow-cat-images"
   generate_lgtm_image_upload_bucket = "${local.env}-lgtmeow-created-lgtm-images"
   convert_to_webp_upload_bucket     = "${local.env}-lgtmeow-images"


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-terraform/issues/117

# Doneの定義
https://github.com/nekochans/lgtm-cat-terraform/issues/117 の完了の定義が満たされていること

# 変更点概要
LambdaがS3バケットからファイルダウンロード、S3へのアップロードができるように以下の変更を行った。
[LambdaのIAM RoleにS3へのアクションを許可するためのカスタマーインラインpolicyを追加](https://github.com/nekochans/lgtm-cat-terraform/pull/118/commits/8946ec5d97dca5dc68ab3b2ac210d0d9a4bbe7c2)

Issueとは関係ないが、module側でリソースIDを定義した方が可読性が高くなり、moduleに渡す変数も減らすことで意図しないリソースIDをつけてしまうミスを減らせると思い下記のリファクタリングを行った。
[リソースIDをmodule側で定義するようにリファクタリング](https://github.com/nekochans/lgtm-cat-terraform/commit/39c7cd386197b6cd45dfd877f2931239e37c61ff)

# レビュアーに重点的にチェックして欲しい点
リファクタリングの観点に問題がないかどうかレビューお願いします。