### PR TITLE
lmgt-cat-processor Lambdaの設定を画像処理を行うのに必要なメモリ、タイムアウト時間に変更

### DIFF
--- a/modules/aws/lgtm-image-processor/lambda.tf
+++ b/modules/aws/lgtm-image-processor/lambda.tf
@@ -5,8 +5,8 @@ resource "aws_lambda_function" "lgtm_image_processor" {
   role          = aws_iam_role.lambda.arn
 
   architectures = ["arm64"]
-  memory_size   = 128
-  timeout       = 30
+  memory_size   = 256
+  timeout       = 180
 
   environment {
     variables = {


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-terraform/issues/119

# Doneの定義
https://github.com/nekochans/lgtm-cat-terraform/issues/119 の完了の定義が満たされていること

# 変更点概要

Lamndaのメモリ、タイムアウト時間を変更。
設定値についてはSTG検証した値を元に設定した。
