### PR TITLE
SSM パラメータストアにCognito App clients IDを追加

### DIFF
--- a/modules/aws/cognito/outputs.tf
+++ b/modules/aws/cognito/outputs.tf
@@ -9,3 +9,7 @@ output "lgtm_cat_bff_client_id" {
 output "cognito_user_pool_id" {
   value = aws_cognito_user_pool.user_pool.id
 }
+
+output "cognito_app_client_id" {
+  value = aws_cognito_user_pool_client.lgtm_cat_bff_client.id
+}

--- a/modules/aws/ecs/ssm.tf
+++ b/modules/aws/ecs/ssm.tf
@@ -33,3 +33,9 @@ resource "aws_ssm_parameter" "cognito_user_pool_id" {
   type  = "SecureString"
   value = var.cognito_user_pool_id
 }
+
+resource "aws_ssm_parameter" "cognito_app_client_id" {
+  name  = "/${var.env}/lgtm-cat/api/COGNITO_APP_CLIENT_ID"
+  type  = "SecureString"
+  value = var.cognito_app_client_id
+}

--- a/modules/aws/ecs/variables.tf
+++ b/modules/aws/ecs/variables.tf
@@ -49,5 +49,8 @@ variable "sentry_dsn" {
 variable "cognito_user_pool_id" {
   type = string
 }
+variable "cognito_app_client_id" {
+  type = string
+}
 
 data "aws_region" "current" {}

--- a/providers/aws/environments/prod/17-cognito/outputs.tf
+++ b/providers/aws/environments/prod/17-cognito/outputs.tf
@@ -12,3 +12,8 @@ output "cognito_user_pool_id" {
   value     = module.cognito.cognito_user_pool_id
   sensitive = true
 }
+
+output "cognito_app_client_id" {
+  value     = module.cognito.cognito_app_client_id
+  sensitive = true
+}

--- a/providers/aws/environments/prod/20-api/main.tf
+++ b/providers/aws/environments/prod/20-api/main.tf
@@ -27,4 +27,5 @@ module "ecs" {
   db_username               = local.db_username
   sentry_dsn                = local.sentry_dsn
   cognito_user_pool_id      = data.terraform_remote_state.cognito.outputs.cognito_user_pool_id
+  cognito_app_client_id     = data.terraform_remote_state.cognito.outputs.cognito_app_client_id
 }

--- a/providers/aws/environments/stg/17-cognito/outputs.tf
+++ b/providers/aws/environments/stg/17-cognito/outputs.tf
@@ -12,3 +12,8 @@ output "cognito_user_pool_id" {
   value     = module.cognito.cognito_user_pool_id
   sensitive = true
 }
+
+output "cognito_app_client_id" {
+  value     = module.cognito.cognito_app_client_id
+  sensitive = true
+}

--- a/providers/aws/environments/stg/20-api/main.tf
+++ b/providers/aws/environments/stg/20-api/main.tf
@@ -27,4 +27,5 @@ module "ecs" {
   db_username               = local.db_username
   sentry_dsn                = local.sentry_dsn
   cognito_user_pool_id      = data.terraform_remote_state.cognito.outputs.cognito_user_pool_id
+  cognito_app_client_id     = data.terraform_remote_state.cognito.outputs.cognito_app_client_id
 }


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-terraform/issues/132

# 関連URL
[optional]

# Doneの定義
#132 の通り

> STG・本番環境のTerraformコードに、Cognito App clients IDをSSM Parameter Storeに登録するリソースが定義されていること

# 変更点概要
STG・本番環境のSSM パラメータストアにCognito App clients IDを追加。
STGのみapply実行済み。

# 補足
https://github.com/nekochans/lgtm-cat-api/pull/42 の対応で必要となる。