### PR TITLE
Python版 lgtm-cat-api への移行用リソース(v2)の削除

### DIFF
--- a/modules/aws/ecs/alb.tf
+++ b/modules/aws/ecs/alb.tf
@@ -26,8 +26,6 @@ resource "aws_alb_target_group" "api_public" {
 
 resource "aws_alb_listener" "api_public" {
   default_action {
-    # python版に切り替える際に、以下に変更する
-    # target_group_arn = aws_alb_target_group.api_v2_public
     target_group_arn = aws_alb_target_group.api_public.id
     type             = "forward"
   }
@@ -37,37 +35,4 @@ resource "aws_alb_listener" "api_public" {
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-TLS-1-2-Ext-2018-06"
   certificate_arn   = var.certificate_arn
-}
-
-resource "aws_alb_target_group" "api_v2_public" {
-  name        = "${var.name}-v2"
-  port        = 80
-  protocol    = "HTTP"
-  vpc_id      = var.vpc_id
-  target_type = "ip"
-
-  health_check {
-    path                = "/health-checks"
-    timeout             = 5
-    healthy_threshold   = 5
-    unhealthy_threshold = 2
-    interval            = 20
-    matcher             = 200
-  }
-}
-
-resource "aws_lb_listener_rule" "api_public_preview" {
-  listener_arn = aws_alb_listener.api_public.id
-  priority     = 10
-
-  action {
-    type             = "forward"
-    target_group_arn = aws_alb_target_group.api_v2_public.id
-  }
-
-  condition {
-    path_pattern {
-      values = ["/v2/*"]
-    }
-  }
 }

--- a/modules/aws/ecs/ecr.tf
+++ b/modules/aws/ecs/ecr.tf
@@ -39,27 +39,3 @@ resource "aws_ecr_lifecycle_policy" "api_nginx" {
   repository = aws_ecr_repository.api_nginx.name
   policy     = local.lifecycle_policy
 }
-
-
-resource "aws_ecr_repository" "api_v2_app" {
-  name = "${var.name}-v2-app"
-  # CDの構築後にIMMUTABLEに変更する
-  image_tag_mutability = "MUTABLE"
-}
-
-resource "aws_ecr_repository" "api_v2_nginx" {
-  name = "${var.name}-v2-nginx"
-  # CDの構築後にIMMUTABLEに変更する
-  image_tag_mutability = "MUTABLE"
-}
-
-
-resource "aws_ecr_lifecycle_policy" "api_v2_app" {
-  repository = aws_ecr_repository.api_v2_app.name
-  policy     = local.lifecycle_policy
-}
-
-resource "aws_ecr_lifecycle_policy" "api_v2_nginx" {
-  repository = aws_ecr_repository.api_v2_nginx.name
-  policy     = local.lifecycle_policy
-}

--- a/modules/aws/ecs/ecs.tf
+++ b/modules/aws/ecs/ecs.tf
@@ -39,36 +39,3 @@ resource "aws_ecs_service" "api" {
 
   depends_on = [aws_alb_listener.api_public]
 }
-
-resource "aws_ecs_service" "api_v2" {
-  name    = "${var.name}-v2"
-  cluster = aws_ecs_cluster.api.id
-  // タスクの定義は Terraform ではなく lgtm-cat-api リポジトリで管理
-  task_definition  = ""
-  desired_count    = var.ecs_service_desired_count
-  launch_type      = "FARGATE"
-  platform_version = "1.4.0"
-
-  load_balancer {
-    target_group_arn = aws_alb_target_group.api_v2_public.id
-    container_name   = "nginx"
-    container_port   = 80
-  }
-
-  network_configuration {
-    subnets          = var.subnet_public_ids
-    assign_public_ip = true
-
-    security_groups = [
-      aws_security_group.api_ecs.id,
-    ]
-  }
-
-  lifecycle {
-    ignore_changes = [
-      task_definition,
-    ]
-  }
-
-  depends_on = [aws_alb_listener.api_public]
-}


### PR DESCRIPTION
# issueURL
#129

# この PR で対応する範囲 / この PR で対応しない範囲

対応範囲:
- ALBのv2ターゲットグループとリスナールールを削除
- ECRのv2リポジトリとライフサイクルポリシーを削除
- ECSのv2サービスを削除
- 不要になったコメント（v2関連の記述）を削除

対応しない範囲:
- 特になし
    - このPRでPython版 lgtm-cat-api への移行作業は完了する
    - lgtm-cat-apiのデプロイ先の変更は https://github.com/nekochans/lgtm-cat-api/pull/48 で対応

# 変更点概要
Python版のlgtm-cat-apiへの移行が完了したため、移行用に作成していたv2リソースを削除する。

Go版からPython版への移行のためにv2リソースを作成していた。当初はGo版のリソースを削除し、v2リソースを本番用として残す計画だったが、方針を変更し、Go版で利用していた非v2リソースにPython版をデプロイする形とした。そのため、移行用のv2リソースは不要となり削除する。

stg環境で削除を実施し、ダウンタイムなしで完了することを確認済み。

## 変更内容
- ALBのv2ターゲットグループとリスナールールを削除
- ECRのv2リポジトリとライフサイクルポリシーを削除
- ECSのv2サービスを削除
- 不要になったコメントを削除

## 削除対象リソース
### ALB関連
- `aws_alb_target_group.api_v2_public`
- `aws_lb_listener_rule.api_public_preview`

### ECR関連
- `aws_ecr_repository.api_v2_app`
- `aws_ecr_repository.api_v2_nginx`
- `aws_ecr_lifecycle_policy.api_v2_app`
- `aws_ecr_lifecycle_policy.api_v2_nginx`

### ECS関連
- `aws_ecs_service.api_v2`
