### PR TITLE
Amazon Q Developer Chat経由でECSサービスをスケールするためのリソースを追加

### DIFF
--- a/modules/aws/q-developver-chat/iam.tf
+++ b/modules/aws/q-developver-chat/iam.tf
@@ -1,0 +1,46 @@
+data "aws_iam_policy_document" "ecs_scale_assume_role" {
+  statement {
+    effect = "Allow"
+
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["chatbot.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "ecs_scale" {
+  name               = "${var.name}-ecs-scale-role"
+  assume_role_policy = data.aws_iam_policy_document.ecs_scale_assume_role.json
+}
+
+data "aws_iam_policy_document" "ecs_scale" {
+  statement {
+    sid    = "AllowUpdateEcsService"
+    effect = "Allow"
+
+    actions = [
+      "ecs:UpdateService",
+      "ecs:DescribeServices",
+      "ecs:ListServices",
+      "ecs:DescribeClusters"
+    ]
+
+    resources = [
+      "arn:aws:ecs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:cluster/${var.env}-lgtm-cat-api",
+      "arn:aws:ecs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:service/${var.env}-lgtm-cat-api/${var.env}-lgtm-cat-api"
+    ]
+  }
+}
+
+resource "aws_iam_policy" "ecs_scale" {
+  name   = "${var.name}-ecs-scale-policy"
+  policy = data.aws_iam_policy_document.ecs_scale.json
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_scale_attach" {
+  role       = aws_iam_role.ecs_scale.name
+  policy_arn = aws_iam_policy.ecs_scale.arn
+}

--- a/modules/aws/q-developver-chat/slack_channel_config.tf
+++ b/modules/aws/q-developver-chat/slack_channel_config.tf
@@ -1,0 +1,7 @@
+resource "aws_chatbot_slack_channel_configuration" "ecs_scale" {
+  configuration_name    = "${var.name}-ecs-scale"
+  iam_role_arn          = aws_iam_role.ecs_scale.arn
+  slack_channel_id      = jsondecode(data.aws_secretsmanager_secret_version.secret.secret_string)["ecs_scale_slack_channel_id"]
+  slack_team_id         = jsondecode(data.aws_secretsmanager_secret_version.secret.secret_string)["amazon_q_developer_slack_workspace_id"]
+  guardrail_policy_arns = [aws_iam_policy.ecs_scale.arn]
+}

--- a/modules/aws/q-developver-chat/variables.tf
+++ b/modules/aws/q-developver-chat/variables.tf
@@ -1,0 +1,18 @@
+variable "env" {
+  type = string
+}
+
+variable "name" {
+  type = string
+}
+
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+
+data "aws_secretsmanager_secret" "secret" {
+  name = "/${var.env}/lgtm-cat"
+}
+
+data "aws_secretsmanager_secret_version" "secret" {
+  secret_id = data.aws_secretsmanager_secret.secret.id
+}

--- a/providers/aws/environments/stg/25-q-developer-chat/.terraform.lock.hcl
+++ b/providers/aws/environments/stg/25-q-developer-chat/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.18.0"
+  constraints = "6.18.0"
+  hashes = [
+    "h1:kYe4gKHOceVoJE3tShRYRdHRD3FTJPkIE5mRrejTrBI=",
+    "zh:0f22732930b4f51e345a2273cd92bd419a33d07bb6add096be09771eb391ed0e",
+    "zh:164582e9be87e6ac2765d414269439ee2bc6f5a831e0d57d204e88006bce6cf7",
+    "zh:47b0b230d100a270f5cb5a4ed7b2b0b3caef66cfd407617da558318279a8bb1b",
+    "zh:73ac86ba28ec32357abbfd60742b9cdebfda59f65161f64f8246de1eaca45f38",
+    "zh:7c68d3a83da55bf63972d50c4c5a6759e0c44ed74aa7fb3d70dd7ef1850cab34",
+    "zh:8b0873c78e62e7930f2d0f9f232cacb6e3b34e6e4ec41989d43c591529a3f9d7",
+    "zh:8e8017c67317811339fed4a5fe2568b025bdd3aeaad4e16186fbb24393d09d2d",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:ae7cc2d08ab9c6ced8291a7521ab3783d4e55cf4e18a36c8a487c6dfd3fb064e",
+    "zh:ce0ccfed27f03d7366ba4a199ded19f9cc47b8a8a47922263b29eb9d4b42ce66",
+    "zh:d165703f775c3f38891a53451fc2c11c68bd26262506aeb5354d8a75cabdfc3d",
+    "zh:dc57c8e2b1307bfc05bc4b525de00ada58ca14b7a1737c969413833f4db50fc6",
+    "zh:df09c6125eb353e4fe5ba73c16c88617a1c4b41c7fca81bd257884966d942b54",
+    "zh:df9c94ed15d88b921876c9cd52942693743d5b0b5b9650bae5498117a44aae4e",
+    "zh:fbcb0c7a5aff9eb794093c94fd98989739f0e0d377a6e8a15b4910703c13e228",
+  ]
+}

--- a/providers/aws/environments/stg/25-q-developer-chat/backend.tf
+++ b/providers/aws/environments/stg/25-q-developer-chat/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket  = "stg-lgtm-cat-tfstate"
+    key     = "q-developer-chat/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "lgtm-cat"
+  }
+}

--- a/providers/aws/environments/stg/25-q-developer-chat/main.tf
+++ b/providers/aws/environments/stg/25-q-developer-chat/main.tf
@@ -1,0 +1,6 @@
+module "ecs_scale" {
+  source = "../../../../../modules/aws/q-developver-chat"
+
+  env  = local.env
+  name = local.name
+}

--- a/providers/aws/environments/stg/25-q-developer-chat/provider.tf
+++ b/providers/aws/environments/stg/25-q-developer-chat/provider.tf
@@ -1,0 +1,4 @@
+provider "aws" {
+  region  = "ap-northeast-1"
+  profile = "lgtm-cat"
+}

--- a/providers/aws/environments/stg/25-q-developer-chat/variables.tf
+++ b/providers/aws/environments/stg/25-q-developer-chat/variables.tf
@@ -1,0 +1,4 @@
+locals {
+  env  = "stg"
+  name = "${local.env}-lgtm-cat-api"
+}

--- a/providers/aws/environments/stg/25-q-developer-chat/versions.tf
+++ b/providers/aws/environments/stg/25-q-developer-chat/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = "1.0.3"
+
+  required_providers {
+    aws = "6.18.0"
+  }
+}


### PR DESCRIPTION
# issueURL
#134

# この PR で対応する範囲 / この PR で対応しない範囲

対応範囲:
- AWS Chatbot Slack チャンネル設定を追加
- ECSサービスのスケーリング権限を持つIAMロールとポリシーを作成
- ステージング環境用の設定ファイルを追加

対応しない範囲:
- 本番環境への設定追加

# 変更点概要
Amazon Q Developer ChatからSlack経由でECSサービスのdesired_countを変更できるようにするためのリソースをstg環境に追加する。

開発時にstg環境のAPIを一時的に起動・停止する際の運用を効率化することが目的。本番環境は常時稼働させるため、この機能は不要と判断。

## 変更内容
- AWS Chatbot Slack チャンネル設定を追加
  - Slack チャンネルIDとワークスペースIDはSecrets Managerから取得
  - Secrets ManagerへはAWSコンソールから登録済み
- ECSサービスのスケーリング権限を持つIAMロールとポリシーを作成
  - `ecs:UpdateService`、`ecs:DescribeServices`、`ecs:ListServices`、`ecs:DescribeClusters` の権限を付与
  - 対象リソースは `stg-lgtm-cat-api` クラスターとサービスに限定
- ステージング環境用の設定ファイルを追加
  - Terraform バックエンド設定
  - プロバイダー設定
  - モジュール呼び出し設定

## 追加リソース
### AWS Chatbot関連
- `aws_chatbot_slack_channel_configuration.ecs_scale`

### IAM関連
- `aws_iam_role.ecs_scale`
- `aws_iam_policy.ecs_scale`
- `aws_iam_role_policy_attachment.ecs_scale_attach`

# 補足
補足事項はインラインコメントに記載。
Terraform以外の設定については、以下のスクラップ記事に記載した。
https://zenn.dev/kobayashi_m42/scraps/110eb7ff46c2b1