### PR TITLE
画像許可ドメイン設定用のSSMパラメータを追加

### DIFF
--- a/modules/aws/ecs/ssm.tf
+++ b/modules/aws/ecs/ssm.tf
@@ -39,3 +39,9 @@ resource "aws_ssm_parameter" "cognito_app_client_id" {
   type  = "SecureString"
   value = var.cognito_app_client_id
 }
+
+resource "aws_ssm_parameter" "image_allowed_domain" {
+  name  = "/${var.env}/lgtm-cat/api/IMAGE_ALLOWED_DOMAIN"
+  type  = "SecureString"
+  value = var.image_allowed_domain
+}

--- a/modules/aws/ecs/variables.tf
+++ b/modules/aws/ecs/variables.tf
@@ -52,5 +52,8 @@ variable "cognito_user_pool_id" {
 variable "cognito_app_client_id" {
   type = string
 }
+variable "image_allowed_domain" {
+  type = string
+}
 
 data "aws_region" "current" {}

--- a/providers/aws/environments/prod/20-api/main.tf
+++ b/providers/aws/environments/prod/20-api/main.tf
@@ -28,4 +28,5 @@ module "ecs" {
   sentry_dsn                = local.sentry_dsn
   cognito_user_pool_id      = data.terraform_remote_state.cognito.outputs.cognito_user_pool_id
   cognito_app_client_id     = data.terraform_remote_state.cognito.outputs.cognito_app_client_id
+  image_allowed_domain      = local.image_allowed_domain
 }

--- a/providers/aws/environments/prod/20-api/variables.tf
+++ b/providers/aws/environments/prod/20-api/variables.tf
@@ -13,11 +13,12 @@ locals {
   ecs_service_desired_count = 1
   log_retention_in_days     = 3
 
-  sentry_dsn  = jsondecode(data.aws_secretsmanager_secret_version.secret.secret_string)["sentry_dsn"]
-  db_password = jsondecode(data.aws_secretsmanager_secret_version.secret.secret_string)["db_app_password"]
-  db_username = jsondecode(data.aws_secretsmanager_secret_version.secret.secret_string)["db_app_user"]
-  db_name     = jsondecode(data.aws_secretsmanager_secret_version.secret.secret_string)["db_name"]
-  db_hostname = jsondecode(data.aws_secretsmanager_secret_version.secret.secret_string)["db_host"]
+  sentry_dsn           = jsondecode(data.aws_secretsmanager_secret_version.secret.secret_string)["sentry_dsn"]
+  db_password          = jsondecode(data.aws_secretsmanager_secret_version.secret.secret_string)["db_app_password"]
+  db_username          = jsondecode(data.aws_secretsmanager_secret_version.secret.secret_string)["db_app_user"]
+  db_name              = jsondecode(data.aws_secretsmanager_secret_version.secret.secret_string)["db_name"]
+  db_hostname          = jsondecode(data.aws_secretsmanager_secret_version.secret.secret_string)["db_host"]
+  image_allowed_domain = jsondecode(data.aws_secretsmanager_secret_version.secret.secret_string)["image_allowed_domain"]
 }
 
 variable "main_domain_name" {

--- a/providers/aws/environments/stg/20-api/main.tf
+++ b/providers/aws/environments/stg/20-api/main.tf
@@ -28,4 +28,5 @@ module "ecs" {
   sentry_dsn                = local.sentry_dsn
   cognito_user_pool_id      = data.terraform_remote_state.cognito.outputs.cognito_user_pool_id
   cognito_app_client_id     = data.terraform_remote_state.cognito.outputs.cognito_app_client_id
+  image_allowed_domain      = local.image_allowed_domain
 }

--- a/providers/aws/environments/stg/20-api/variables.tf
+++ b/providers/aws/environments/stg/20-api/variables.tf
@@ -13,11 +13,12 @@ locals {
   ecs_service_desired_count = 0
   log_retention_in_days     = 3
 
-  sentry_dsn  = jsondecode(data.aws_secretsmanager_secret_version.secret.secret_string)["sentry_dsn"]
-  db_password = jsondecode(data.aws_secretsmanager_secret_version.secret.secret_string)["db_app_password"]
-  db_username = jsondecode(data.aws_secretsmanager_secret_version.secret.secret_string)["db_app_user"]
-  db_name     = jsondecode(data.aws_secretsmanager_secret_version.secret.secret_string)["db_name"]
-  db_hostname = jsondecode(data.aws_secretsmanager_secret_version.secret.secret_string)["db_host"]
+  sentry_dsn           = jsondecode(data.aws_secretsmanager_secret_version.secret.secret_string)["sentry_dsn"]
+  db_password          = jsondecode(data.aws_secretsmanager_secret_version.secret.secret_string)["db_app_password"]
+  db_username          = jsondecode(data.aws_secretsmanager_secret_version.secret.secret_string)["db_app_user"]
+  db_name              = jsondecode(data.aws_secretsmanager_secret_version.secret.secret_string)["db_name"]
+  db_hostname          = jsondecode(data.aws_secretsmanager_secret_version.secret.secret_string)["db_host"]
+  image_allowed_domain = jsondecode(data.aws_secretsmanager_secret_version.secret.secret_string)["image_allowed_domain"]
 }
 
 variable "main_domain_name" {


### PR DESCRIPTION
# issueURL

#144

# この PR で対応する範囲 / この PR で対応しない範囲

**対応する範囲:**
- ECSタスク定義で使用する`IMAGE_ALLOWED_DOMAIN`環境変数をSSM Parameter Storeで管理できるようにした
- prod環境とstg環境の両方に対応

**対応しない範囲:**
- アプリケーション側での環境変数の利用実装

# 変更点概要

画像のアップロード元として許可するドメインを制御するための`IMAGE_ALLOWED_DOMAIN`環境変数を、SSM Parameter Storeで管理できるように設定を追加した。

**変更内容:**
1. ECSモジュールに新しいSSMパラメータ`image_allowed_domain`を追加
2. Secrets Managerから値を読み取るための変数定義を追加
3. prod/stg両環境の20-apiディレクトリで新しいパラメータを参照

# 補足情報

Secrets Manager（`/prod/lgtm-cat`と`/stg/lgtm-cat`）には既に`image_allowed_domain`キーが登録済みである。