### PR TITLE
Lambda関数にRekognitionサービスの実行権限を追加

### DIFF
--- a/modules/aws/lgtm-image-processor/iam.tf
+++ b/modules/aws/lgtm-image-processor/iam.tf
@@ -41,6 +41,20 @@ resource "aws_iam_role_policy" "lambda_s3" {
   policy = data.aws_iam_policy_document.lambda_s3.json
 }
 
+data "aws_iam_policy_document" "lambda_rekognition" {
+  statement {
+    effect    = "Allow"
+    actions   = ["rekognition:DetectLabels"]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "lambda_rekognition" {
+  name   = "${var.env}-${var.service_name}-lambda-rekognition-policy"
+  role   = aws_iam_role.lambda.id
+  policy = data.aws_iam_policy_document.lambda_rekognition.json
+}
+
 #StepFunctions
 data "aws_iam_policy_document" "step_functions_assume_role" {
   statement {


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-terraform/issues/146

# この PR で対応する範囲 / この PR で対応しない範囲

## 対応する範囲
- lgtm-image-processor モジュールのLambda IAMロールに `rekognition:DetectLabels` 権限を追加

## 対応しない範囲
- 実際のRekognition呼び出し処理の実装（アプリケーション側で対応）
- https://github.com/nekochans/lgtm-cat-processor/pull/33

# 変更点概要

`modules/aws/lgtm-image-processor/iam.tf` に以下を追加：
- `lambda_rekognition` IAMポリシードキュメント（DetectLabelsアクションを許可）
- Lambda実行ロールへのポリシーアタッチ

画像処理Lambda関数がAmazon Rekognitionを利用して猫を検出できるようになる。