### PR TITLE
lgtm-image-processor のStepFunctionsに画像インデックス作成処理を追加

### DIFF
--- a/modules/aws/lgtm-image-processor/files/step-function.json
+++ b/modules/aws/lgtm-image-processor/files/step-function.json
@@ -31,6 +31,22 @@
           }
         }
       },
+      "Next": "createImageIndex"
+    },
+    "createImageIndex": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "OutputPath": "$.Payload",
+      "Parameters": {
+        "FunctionName": "${lambda_arn}:$LATEST",
+        "Payload": {
+          "process": "createImageIndex",
+          "image": {
+            "bucketName.$": "$.image.bucketName",
+            "objectKey.$": "$.image.objectKey"
+          }
+        }
+      },
       "End": true
     }
   }


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-terraform/issues/150

# この PR で対応する範囲 / この PR で対応しない範囲

**対応する範囲**
- 既存のStepFunctions のワークフローに画像インデックス作成処理を追加

**対応しない範囲**
- 特になし #150 の完了の定義を満たす

# 変更点概要

既存のStepFunctions のワークフローに画像インデックス作成処理を追加した。
これにより、S3に画像がアップロードされるとDBへの保存が成功した場合に、画像インデックス作成処理を行うLambdaが実行される。
なお、DBへの保存が失敗した場合は、インデックス作成処理が行われない。

# 補足情報
StepFunctionsの遷移図(これはインデックス処理が失敗した場合の例)
<img width="380" height="423" alt="スクリーンショット 2025-11-10 9 44 33" src="https://github.com/user-attachments/assets/8de28850-8905-485f-b2dc-72348f723115" />

# レビュアーに重点的にチェックして欲しい点
storeToDb が失敗した場合、その後の createImageIndex を実行しても意味がないため、storeToDb で例外が発生した時点で Step Functions 全体を失敗として終了させる方針としたが、この方針で問題ないか。