### PR TITLE
Lambda画像処理関数にBedrockとS3 Vectorsへのアクセス権限を追加

### DIFF
--- a/modules/aws/lgtm-image-processor/iam.tf
+++ b/modules/aws/lgtm-image-processor/iam.tf
@@ -55,6 +55,38 @@ resource "aws_iam_role_policy" "lambda_rekognition" {
   policy = data.aws_iam_policy_document.lambda_rekognition.json
 }
 
+data "aws_iam_policy_document" "lambda_bedrock" {
+  statement {
+    effect  = "Allow"
+    actions = ["bedrock:InvokeModel"]
+    resources = [
+      "arn:aws:bedrock:${var.bedrock_region}::foundation-model/cohere.embed-v4:0"
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "lambda_bedrock" {
+  name   = "${var.env}-${var.service_name}-lambda-bedrock-policy"
+  role   = aws_iam_role.lambda.id
+  policy = data.aws_iam_policy_document.lambda_bedrock.json
+}
+
+data "aws_iam_policy_document" "lambda_s3vectors" {
+  statement {
+    effect  = "Allow"
+    actions = ["s3vectors:PutVectors"]
+    resources = [
+      "arn:aws:s3vectors:${var.s3vectors_region}:${data.aws_caller_identity.current.account_id}:bucket/${var.vector_index_bucket}/index/${var.vector_index_name}"
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "lambda_s3vectors" {
+  name   = "${var.env}-${var.service_name}-lambda-s3vectors-policy"
+  role   = aws_iam_role.lambda.id
+  policy = data.aws_iam_policy_document.lambda_s3vectors.json
+}
+
 #StepFunctions
 data "aws_iam_policy_document" "step_functions_assume_role" {
   statement {

--- a/modules/aws/lgtm-image-processor/variables.tf
+++ b/modules/aws/lgtm-image-processor/variables.tf
@@ -26,6 +26,22 @@ variable "lambda_function_name" {
   type = string
 }
 
+variable "vector_index_bucket" {
+  type = string
+}
+
+variable "vector_index_name" {
+  type = string
+}
+
+variable "s3vectors_region" {
+  type = string
+}
+
+variable "bedrock_region" {
+  type = string
+}
+
 data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}
 

--- a/providers/aws/environments/prod/22-lgtm-image-processor/main.tf
+++ b/providers/aws/environments/prod/22-lgtm-image-processor/main.tf
@@ -7,6 +7,10 @@ module "lgtm_image_processor" {
   upload_images_bucket              = local.upload_images_bucket
   judge_image_upload_bucket         = local.judge_image_upload_bucket
   generate_lgtm_image_upload_bucket = local.generate_lgtm_image_upload_bucket
+  vector_index_bucket               = local.vector_index_bucket
+  vector_index_name                 = local.vector_index_name
+  s3vectors_region                  = local.s3vectors_region
+  bedrock_region                    = local.bedrock_region
   lambda_function_name              = local.lambda_function_name
 }
 

--- a/providers/aws/environments/prod/22-lgtm-image-processor/variables.tf
+++ b/providers/aws/environments/prod/22-lgtm-image-processor/variables.tf
@@ -6,6 +6,10 @@ locals {
   upload_images_bucket              = "${local.env}-lgtmeow-cat-images"
   judge_image_upload_bucket         = "${local.env}-lgtmeow-cat-images"
   generate_lgtm_image_upload_bucket = "${local.env}-lgtmeow-images"
+  vector_index_bucket               = "${local.env}-lgtm-cat-vectors"
+  vector_index_name                 = "${local.env}-multimodal-search-index"
   lambda_function_name              = "${local.env}-${local.service_name}"
+  s3vectors_region                  = "us-east-1"
+  bedrock_region                    = "us-east-1"
   codebuild_log_retention_in_days   = 3
 }

--- a/providers/aws/environments/stg/22-lgtm-image-processor/main.tf
+++ b/providers/aws/environments/stg/22-lgtm-image-processor/main.tf
@@ -7,6 +7,10 @@ module "lgtm_image_processor" {
   upload_images_bucket              = local.upload_images_bucket
   judge_image_upload_bucket         = local.judge_image_upload_bucket
   generate_lgtm_image_upload_bucket = local.generate_lgtm_image_upload_bucket
+  vector_index_bucket               = local.vector_index_bucket
+  vector_index_name                 = local.vector_index_name
+  s3vectors_region                  = local.s3vectors_region
+  bedrock_region                    = local.bedrock_region
   lambda_function_name              = local.lambda_function_name
 }
 

--- a/providers/aws/environments/stg/22-lgtm-image-processor/variables.tf
+++ b/providers/aws/environments/stg/22-lgtm-image-processor/variables.tf
@@ -6,6 +6,10 @@ locals {
   upload_images_bucket              = "${local.env}-lgtmeow-cat-images"
   judge_image_upload_bucket         = "${local.env}-lgtmeow-cat-images"
   generate_lgtm_image_upload_bucket = "${local.env}-lgtmeow-images"
+  vector_index_bucket               = "${local.env}-lgtm-cat-vectors"
+  vector_index_name                 = "${local.env}-multimodal-search-index"
   lambda_function_name              = "${local.env}-${local.service_name}"
+  s3vectors_region                  = "us-east-1"
+  bedrock_region                    = "us-east-1"
   codebuild_log_retention_in_days   = 3
 }


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-terraform/issues/149

# この PR で対応する範囲 / この PR で対応しない範囲

## 対応する範囲
- lgtm-image-processor LambdaのIAMロールにBedrock呼び出し権限を追加
- lgtm-image-processor LambdaのIAMロールにS3 Vectorsへのアクセス権限を追加

## 対応しない範囲
- Lambda関数本体のコード実装（別リポジトリで対応）

# 変更点概要

Lambda画像処理関数で画像の埋め込みベクトルを生成してベクターインデックスに保存するため、以下のIAMポリシーを追加した。

- **Bedrockへのアクセス権限**: `bedrock:InvokeModel` により Cohere Embed v4モデルを使用した画像のベクトル化を実行できる
- **S3 Vectorsへのアクセス権限**: `s3vectors:PutVectors` により Vector Index へのベクトル登録が可能となる

また、環境ごとに以下の変数を設定した。
- `vector_index_bucket`: ベクトルインデックスを格納するS3ディレクトリバケット名
- `vector_index_name`: ベクトルインデックス名
- `s3vectors_region`: S3 Vectors のリージョン (us-east-1)
- `bedrock_region`: Bedrock のリージョン (us-east-1)