### PR TITLE
テキスト検索APIに対応するためlgtm-cat-api ECSタスクロールにBedrockとS3 Vectorsへのアクセス権限を追加

### DIFF
--- a/modules/aws/ecs/iam.tf
+++ b/modules/aws/ecs/iam.tf
@@ -69,3 +69,38 @@ resource "aws_iam_role_policy" "ecs_task" {
   role   = aws_iam_role.ecs_task.id
   policy = data.aws_iam_policy_document.task_role_policy.json
 }
+
+data "aws_iam_policy_document" "bedrock_task_role_policy" {
+  statement {
+    effect  = "Allow"
+    actions = ["bedrock:InvokeModel"]
+    resources = [
+      "arn:aws:bedrock:${var.bedrock_region}::foundation-model/cohere.embed-v4:0"
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "bedrock_ecs_task" {
+  name   = "${var.name}-bedrock-ecs-task-role-policy"
+  role   = aws_iam_role.ecs_task.id
+  policy = data.aws_iam_policy_document.bedrock_task_role_policy.json
+}
+
+data "aws_iam_policy_document" "s3vectors_task_role_policy" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3vectors:GetVectors",
+      "s3vectors:QueryVectors"
+    ]
+    resources = [
+      "arn:aws:s3vectors:${var.s3vectors_region}:${data.aws_caller_identity.current.account_id}:bucket/${var.vector_index_bucket}/index/${var.vector_index_name}"
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "s3vectors_ecs_task" {
+  name   = "${var.name}-s3vectors-ecs-task-role-policy"
+  role   = aws_iam_role.ecs_task.id
+  policy = data.aws_iam_policy_document.s3vectors_task_role_policy.json
+}

--- a/modules/aws/ecs/variables.tf
+++ b/modules/aws/ecs/variables.tf
@@ -55,5 +55,18 @@ variable "cognito_app_client_id" {
 variable "image_allowed_domain" {
   type = string
 }
+variable "bedrock_region" {
+  type = string
+}
+variable "s3vectors_region" {
+  type = string
+}
+variable "vector_index_bucket" {
+  type = string
+}
+variable "vector_index_name" {
+  type = string
+}
 
 data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}

--- a/providers/aws/environments/prod/20-api/main.tf
+++ b/providers/aws/environments/prod/20-api/main.tf
@@ -29,4 +29,8 @@ module "ecs" {
   cognito_user_pool_id      = data.terraform_remote_state.cognito.outputs.cognito_user_pool_id
   cognito_app_client_id     = data.terraform_remote_state.cognito.outputs.cognito_app_client_id
   image_allowed_domain      = local.image_allowed_domain
+  vector_index_name         = local.vector_index_name
+  vector_index_bucket       = local.vector_index_bucket
+  s3vectors_region          = local.s3vectors_region
+  bedrock_region            = local.bedrock_region
 }

--- a/providers/aws/environments/prod/20-api/variables.tf
+++ b/providers/aws/environments/prod/20-api/variables.tf
@@ -19,6 +19,11 @@ locals {
   db_name              = jsondecode(data.aws_secretsmanager_secret_version.secret.secret_string)["db_name"]
   db_hostname          = jsondecode(data.aws_secretsmanager_secret_version.secret.secret_string)["db_host"]
   image_allowed_domain = jsondecode(data.aws_secretsmanager_secret_version.secret.secret_string)["image_allowed_domain"]
+
+  vector_index_bucket = "${local.env}-lgtm-cat-vectors"
+  vector_index_name   = "${local.env}-multimodal-search-index"
+  s3vectors_region    = "us-east-1"
+  bedrock_region      = "us-east-1"
 }
 
 variable "main_domain_name" {

--- a/providers/aws/environments/stg/20-api/main.tf
+++ b/providers/aws/environments/stg/20-api/main.tf
@@ -29,4 +29,8 @@ module "ecs" {
   cognito_user_pool_id      = data.terraform_remote_state.cognito.outputs.cognito_user_pool_id
   cognito_app_client_id     = data.terraform_remote_state.cognito.outputs.cognito_app_client_id
   image_allowed_domain      = local.image_allowed_domain
+  vector_index_name         = local.vector_index_name
+  vector_index_bucket       = local.vector_index_bucket
+  s3vectors_region          = local.s3vectors_region
+  bedrock_region            = local.bedrock_region
 }

--- a/providers/aws/environments/stg/20-api/variables.tf
+++ b/providers/aws/environments/stg/20-api/variables.tf
@@ -19,6 +19,11 @@ locals {
   db_name              = jsondecode(data.aws_secretsmanager_secret_version.secret.secret_string)["db_name"]
   db_hostname          = jsondecode(data.aws_secretsmanager_secret_version.secret.secret_string)["db_host"]
   image_allowed_domain = jsondecode(data.aws_secretsmanager_secret_version.secret.secret_string)["image_allowed_domain"]
+
+  vector_index_bucket = "${local.env}-lgtm-cat-vectors"
+  vector_index_name   = "${local.env}-multimodal-search-index"
+  s3vectors_region    = "us-east-1"
+  bedrock_region      = "us-east-1"
 }
 
 variable "main_domain_name" {


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-terraform/issues/156

# この PR で対応する範囲 / この PR で対応しない範囲

## 対応する範囲
- lgtm-cat-api ECSタスクロールにAmazon Bedrock (Cohere Embed v4モデル) へのアクセス権限を追加
- lgtm-cat-api ECSタスクロールにS3 Vectors (ベクトルインデックス) へのクエリ権限を追加
- prod環境とstg環境の両方に対応

## 対応しない範囲
- ベクトルインデックスの作成やデータ投入は別途実施済み
    - https://github.com/nekochans/lgtm-cat-processor/issues/39 の課題で対応 
    - https://github.com/nekochans/lgtm-cat-processor/issues/44 の課題で対応 
- lgtm-cat-apiアプリケーション側の実装変更
    - https://github.com/nekochans/lgtm-cat-api/issues/59 の課題で対応 

# 変更点概要

テキスト検索API機能の追加に伴い、lgtm-cat-api ECSタスクが以下のAWSサービスにアクセスできるよう権限を追加する。

1. **Amazon Bedrock権限**
   - Cohere Embed v4モデル (`cohere.embed-v4:0`) への `InvokeModel` 権限
   - リージョン: us-east-1

2. **S3 Vectors権限**
   - ベクトルインデックスへの `GetVectors` および `QueryVectors` 権限
   - リソース: `${env}-lgtm-cat-vectors` バケット内の `${env}-multimodal-search-index` インデックス
   - リージョン: us-east-1

変更ファイル:
- `modules/aws/ecs/iam.tf`: BedrockとS3 Vectors用のIAMポリシーとロールポリシーを追加
- `modules/aws/ecs/variables.tf`: 必要な変数を追加
- `providers/aws/environments/{prod,stg}/20-api/main.tf`: モジュール呼び出しに新しい変数を追加
- `providers/aws/environments/{prod,stg}/20-api/variables.tf`: ベクトルインデックス関連のローカル変数を定義