### PR TITLE
lgtm-cat-api ECSタスクロールにAmazon Rekognition権限を追加

### DIFF
--- a/modules/aws/ecs/iam.tf
+++ b/modules/aws/ecs/iam.tf
@@ -104,3 +104,21 @@ resource "aws_iam_role_policy" "s3vectors_ecs_task" {
   role   = aws_iam_role.ecs_task.id
   policy = data.aws_iam_policy_document.s3vectors_task_role_policy.json
 }
+
+data "aws_iam_policy_document" "rekognition_task_role_policy" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "rekognition:DetectFaces",
+      "rekognition:DetectLabels",
+      "rekognition:DetectModerationLabels"
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "rekognition_ecs_task" {
+  name   = "${var.name}-rekognition-ecs-task-role-policy"
+  role   = aws_iam_role.ecs_task.id
+  policy = data.aws_iam_policy_document.rekognition_task_role_policy.json
+}


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-terraform/issues/159

# この PR で対応する範囲 / この PR で対応しない範囲

## 対応する範囲
- lgtm-cat-api ECSタスクロールにAmazon Rekognition権限を追加

## 対応しない範囲
- lgtm-cat-api側の実装変更

# 変更点概要

lgtm-cat-apiの画像判定APIでAmazon Rekognitionを使用するため、ECSタスクロールに以下の権限を追加した。

- `rekognition:DetectFaces` - 顔検出
- `rekognition:DetectLabels` - ラベル検出
- `rekognition:DetectModerationLabels` - 不適切コンテンツ検出

# 補足情報

本PRは https://github.com/nekochans/lgtm-cat-api/issues/74 の対応に必要となる権限追加である。
