### PR TITLE
本番環境の画像判定API URLを修正

### DIFF
--- a/providers/aws/environments/prod/22-lgtm-image-processor/variables.tf
+++ b/providers/aws/environments/prod/22-lgtm-image-processor/variables.tf
@@ -13,7 +13,7 @@ locals {
   bedrock_region                    = "us-east-1"
   codebuild_log_retention_in_days   = 3
 
-  judge_image_api_url    = "https://api.lgtmeow.com/images/judge"
+  judge_image_api_url    = "https://api.lgtmeow.com"
   cognito_client_id      = data.terraform_remote_state.cognito.outputs.cognito_app_client_id
   cognito_client_secret  = data.terraform_remote_state.cognito.outputs.cognito_client_secret
   cognito_token_endpoint = data.terraform_remote_state.cognito.outputs.cognito_token_endpoint


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-terraform/issues/161

# この PR で対応する範囲 / この PR で対応しない範囲

## 対応する範囲
- 本番環境の`judge_image_api_url`の値を修正

## 対応しない範囲
- ステージング環境の修正（すでに正しい値が設定されている）

# 変更点概要

本番環境の`judge_image_api_url`に誤ったURLが設定されていたため修正する。

- 修正前: `https://api.lgtmeow.com/images/judge`
- 修正後: `https://api.lgtmeow.com`

Lambda関数側でパスを付与するため、ベースURLのみを指定する必要がある。