### PR TITLE
S3 VectorsリソースをTerraform管理に移行し東京リージョンで構築

### DIFF
--- a/modules/aws/s3-vectors/main.tf
+++ b/modules/aws/s3-vectors/main.tf
@@ -1,0 +1,13 @@
+resource "aws_s3vectors_vector_bucket" "main" {
+  vector_bucket_name = var.vector_bucket_name
+  force_destroy      = var.force_destroy
+}
+
+resource "aws_s3vectors_index" "main" {
+  index_name         = var.vector_index_name
+  vector_bucket_name = aws_s3vectors_vector_bucket.main.vector_bucket_name
+
+  data_type       = var.data_type
+  dimension       = var.dimension
+  distance_metric = var.distance_metric
+}

--- a/modules/aws/s3-vectors/variables.tf
+++ b/modules/aws/s3-vectors/variables.tf
@@ -1,0 +1,27 @@
+variable "vector_bucket_name" {
+  type = string
+}
+
+variable "vector_index_name" {
+  type = string
+}
+
+variable "data_type" {
+  type    = string
+  default = "float32"
+}
+
+variable "dimension" {
+  type    = number
+  default = 1536
+}
+
+variable "distance_metric" {
+  type    = string
+  default = "cosine"
+}
+
+variable "force_destroy" {
+  type    = bool
+  default = false
+}

--- a/providers/aws/environments/prod/18-s3-vectors/.terraform.lock.hcl
+++ b/providers/aws/environments/prod/18-s3-vectors/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.24.0"
+  constraints = "6.24.0"
+  hashes = [
+    "h1:pJX4irIcMM8crlFKEo92/2IQs6TG4bhq0d5+Ix4oHYQ=",
+    "zh:11283019ffc77cbd445447c74d3b741a155bbaa69162f971cceb394cf4219f4b",
+    "zh:1a561c907cd87a732ee2d84a2178f02af410d49dad8f96901eff61e1b395417d",
+    "zh:31a3337edad9e50b0daef42b67b2ea0b43becafdf74b569b270ac15dc1eab2c4",
+    "zh:3707d429a12bb10831ff3d9d3dc8557bc0c73322ccd2550b71a1711c5b897c22",
+    "zh:71364f96d7cd6c07a22e4a1920f45e3b2c9a9cd4e3992ce32b34cfeebde62f17",
+    "zh:891537027210d2c8af6336d7776674b06e0d2912d84288a3413aad363fc90a77",
+    "zh:99154ea404bd6949afdadbc2a46dfdac75bf94d23cb6287d2ae6da9965ec066a",
+    "zh:9a520955e8b3d735c717e730ddeee2d2b27ac276f140ea805b49b9ef79a34829",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a172bf1f69f798510d7980d4ce7cdfa8d7ee301b4c254e587554133aa1b5f730",
+    "zh:b3496079295b5f41b31e24c8292fe8d685fd21b941927eb654c2e6df3b4d24dd",
+    "zh:b8840f86f001cd64d2d0a2a808062e5c3ba21ebda8387aab39a375c3d618c2e7",
+    "zh:c81f33659a2a66095a6066bddc0bdef52b5d65b54670e03bae7e1dbea1d47640",
+    "zh:cb23eca22acadcee9bf0def6f4d6ead6e04ed564eb8e3d311116545fb6d34401",
+    "zh:ced4f3e74156669f074e30b2c9afa48a3e4062fcafe1d9da1c4db4b569bf82b7",
+  ]
+}

--- a/providers/aws/environments/prod/18-s3-vectors/backend.tf
+++ b/providers/aws/environments/prod/18-s3-vectors/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket  = "lgtm-cat-tfstate"
+    key     = "s3-vectors/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "lgtm-cat"
+  }
+}

--- a/providers/aws/environments/prod/18-s3-vectors/main.tf
+++ b/providers/aws/environments/prod/18-s3-vectors/main.tf
@@ -1,0 +1,10 @@
+module "s3_vectors" {
+  source = "../../../../../modules/aws/s3-vectors"
+
+  vector_bucket_name = local.vector_bucket_name
+  vector_index_name  = local.vector_index_name
+  data_type          = local.data_type
+  dimension          = local.dimension
+  distance_metric    = local.distance_metric
+  force_destroy      = false
+}

--- a/providers/aws/environments/prod/18-s3-vectors/provider.tf
+++ b/providers/aws/environments/prod/18-s3-vectors/provider.tf
@@ -1,0 +1,4 @@
+provider "aws" {
+  region  = "ap-northeast-1"
+  profile = "lgtm-cat"
+}

--- a/providers/aws/environments/prod/18-s3-vectors/variables.tf
+++ b/providers/aws/environments/prod/18-s3-vectors/variables.tf
@@ -1,0 +1,8 @@
+locals {
+  env                = "prod"
+  vector_bucket_name = "${local.env}-lgtm-cat-vectors"
+  vector_index_name  = "${local.env}-multimodal-search-index"
+  data_type          = "float32"
+  dimension          = 1536
+  distance_metric    = "cosine"
+}

--- a/providers/aws/environments/prod/18-s3-vectors/versions.tf
+++ b/providers/aws/environments/prod/18-s3-vectors/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "1.13.4"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "6.24.0"
+    }
+  }
+}

--- a/providers/aws/environments/stg/18-s3-vectors/.terraform.lock.hcl
+++ b/providers/aws/environments/stg/18-s3-vectors/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.24.0"
+  constraints = "6.24.0"
+  hashes = [
+    "h1:pJX4irIcMM8crlFKEo92/2IQs6TG4bhq0d5+Ix4oHYQ=",
+    "zh:11283019ffc77cbd445447c74d3b741a155bbaa69162f971cceb394cf4219f4b",
+    "zh:1a561c907cd87a732ee2d84a2178f02af410d49dad8f96901eff61e1b395417d",
+    "zh:31a3337edad9e50b0daef42b67b2ea0b43becafdf74b569b270ac15dc1eab2c4",
+    "zh:3707d429a12bb10831ff3d9d3dc8557bc0c73322ccd2550b71a1711c5b897c22",
+    "zh:71364f96d7cd6c07a22e4a1920f45e3b2c9a9cd4e3992ce32b34cfeebde62f17",
+    "zh:891537027210d2c8af6336d7776674b06e0d2912d84288a3413aad363fc90a77",
+    "zh:99154ea404bd6949afdadbc2a46dfdac75bf94d23cb6287d2ae6da9965ec066a",
+    "zh:9a520955e8b3d735c717e730ddeee2d2b27ac276f140ea805b49b9ef79a34829",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a172bf1f69f798510d7980d4ce7cdfa8d7ee301b4c254e587554133aa1b5f730",
+    "zh:b3496079295b5f41b31e24c8292fe8d685fd21b941927eb654c2e6df3b4d24dd",
+    "zh:b8840f86f001cd64d2d0a2a808062e5c3ba21ebda8387aab39a375c3d618c2e7",
+    "zh:c81f33659a2a66095a6066bddc0bdef52b5d65b54670e03bae7e1dbea1d47640",
+    "zh:cb23eca22acadcee9bf0def6f4d6ead6e04ed564eb8e3d311116545fb6d34401",
+    "zh:ced4f3e74156669f074e30b2c9afa48a3e4062fcafe1d9da1c4db4b569bf82b7",
+  ]
+}

--- a/providers/aws/environments/stg/18-s3-vectors/backend.tf
+++ b/providers/aws/environments/stg/18-s3-vectors/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket  = "stg-lgtm-cat-tfstate"
+    key     = "s3-vectors/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "lgtm-cat"
+  }
+}

--- a/providers/aws/environments/stg/18-s3-vectors/main.tf
+++ b/providers/aws/environments/stg/18-s3-vectors/main.tf
@@ -1,0 +1,10 @@
+module "s3_vectors" {
+  source = "../../../../../modules/aws/s3-vectors"
+
+  vector_bucket_name = local.vector_bucket_name
+  vector_index_name  = local.vector_index_name
+  data_type          = local.data_type
+  dimension          = local.dimension
+  distance_metric    = local.distance_metric
+  force_destroy      = false
+}

--- a/providers/aws/environments/stg/18-s3-vectors/provider.tf
+++ b/providers/aws/environments/stg/18-s3-vectors/provider.tf
@@ -1,0 +1,4 @@
+provider "aws" {
+  region  = "ap-northeast-1"
+  profile = "lgtm-cat"
+}

--- a/providers/aws/environments/stg/18-s3-vectors/variables.tf
+++ b/providers/aws/environments/stg/18-s3-vectors/variables.tf
@@ -1,0 +1,8 @@
+locals {
+  env                = "stg"
+  vector_bucket_name = "${local.env}-lgtm-cat-vectors"
+  vector_index_name  = "${local.env}-multimodal-search-index"
+  data_type          = "float32"
+  dimension          = 1536
+  distance_metric    = "cosine"
+}

--- a/providers/aws/environments/stg/18-s3-vectors/versions.tf
+++ b/providers/aws/environments/stg/18-s3-vectors/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "1.13.4"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "6.24.0"
+    }
+  }
+}


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-terraform/issues/164

# この PR で対応する範囲 / この PR で対応しない範囲

## 対応する範囲
- S3 Vectors用のTerraformモジュール（`modules/aws/s3-vectors`）の新規作成
- stg環境・prod環境それぞれに`18-s3-vectors`ディレクトリを追加
- 東京リージョン（ap-northeast-1）でのリソース構築

## 対応しない範囲
- 既存のus-east-1リージョンで作成済みのS3 Vectorsリソースの削除・移行（#165 で対応予定）

# 変更点概要

S3 VectorsがGA（一般提供）となりAWS Terraform Provider v6.24.0で正式サポートされたため、AWS CLI管理からTerraform管理へ移行する。

また、現在us-east-1リージョンで運用しているマルチモーダル検索機能を、GAに伴い利用可能になった東京リージョン（ap-northeast-1）へ移行するための準備として、新規リソースを東京リージョンに構築する。

主な変更内容:
- `modules/aws/s3-vectors`: Vector BucketとVector Indexを作成する再利用可能なモジュールを追加
- `providers/aws/environments/stg/18-s3-vectors`: stg環境用の設定
- `providers/aws/environments/prod/18-s3-vectors`: prod環境用の設定

# 補足情報

- AWS Terraform Provider v6.24.0以上が必要
- 参考: [Amazon S3 Vectors - GitHub Issue #43409](https://github.com/hashicorp/terraform-provider-aws/issues/43409)